### PR TITLE
修正validate和guide的两个bug

### DIFF
--- a/elfiee-ext-gen/src/core/guide_gen.rs
+++ b/elfiee-ext-gen/src/core/guide_gen.rs
@@ -234,7 +234,9 @@ impl GuideGenerator {
 
     fn map_category(category: Option<&str>) -> &'static str {
         match category {
-            Some("payload_field_missing") | Some("payload_deserialize_error") => "payload",
+            Some("payload_field_missing")
+            | Some("payload_deserialize_error")
+            | Some("payload_example_missing") => "payload",
             Some("handler_not_implemented") | Some("todo_marker") => "functionality",
             Some("authorization_error") => "authorization",
             Some("workflow_test_todo") => "workflow",

--- a/elfiee-ext-gen/src/core/validator.rs
+++ b/elfiee-ext-gen/src/core/validator.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::utils::naming::to_pascal_case;
 use syn::visit::Visit;
 use syn::{
-    Expr, ExprMethodCall, ExprPath, File, ImplItem, Item, ItemMod, Type, UseTree, Visibility,
+    Expr, ExprMethodCall, ExprPath, File, ImplItem, Item, ItemMod, Stmt, Type, UseTree, Visibility,
 };
 
 // ============================================================================
@@ -409,6 +409,17 @@ fn analyze_registry(file: &File, extension_name: &str) -> RegistryAnalysis {
                         if let ImplItem::Fn(method) = impl_item {
                             if method.sig.ident == "register_extensions" {
                                 has_register_method = true;
+                                for stmt in &method.block.stmts {
+                                    if let Stmt::Item(Item::Use(item_use)) = stmt {
+                                        if use_tree_contains_extension_glob(
+                                            &item_use.tree,
+                                            extension_name,
+                                            Vec::new(),
+                                        ) {
+                                            use_found = true;
+                                        }
+                                    }
+                                }
                                 let mut collector = RegisterCallCollector {
                                     registered: &mut registered_capabilities,
                                 };


### PR DESCRIPTION
修正两个验证的bug：

1. validate没有识别写在extension函数体内的use crate，报错没找到相应的extension
2. guide没把缺失payload实际测试逻辑的错误分类里到payload类错误中，所以在没有实现任何测试/mod.rs中没有任何改动的时候，不会给出payload测试不通过的提示。