### PR TITLE
feat: Implement core engine actor

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -27,11 +27,19 @@ if ! git diff --quiet --ignore-submodules --; then
     fi
 fi
 
-echo "🛠  Running make fmt before commit..."
+echo "🛠  Running make fmt (backend) before commit..."
 
 if ! make fmt >"$LOG_FILE" 2>&1; then
     cat "$LOG_FILE"
     echo "❌ make fmt failed. Please fix the issues above."
+    exit 1
+fi
+
+echo "🧹  Running pnpm format (frontend) before commit..."
+
+if ! pnpm format >"$LOG_FILE" 2>&1; then
+    cat "$LOG_FILE"
+    echo "❌ pnpm format failed. Please fix the issues above."
     exit 1
 fi
 

--- a/src-tauri/src/engine/actor.rs
+++ b/src-tauri/src/engine/actor.rs
@@ -171,8 +171,7 @@ impl ElfileEngineActor {
                 }
                 EngineMessage::GetBlock { block_id, response } => {
                     let mut block = self.state.get_block(&block_id).cloned();
-                    
-                   
+
                     if let Some(ref mut b) = block {
                         self.inject_block_dir_if_possible(b);
                     }
@@ -180,10 +179,11 @@ impl ElfileEngineActor {
                 }
                 EngineMessage::GetAllBlocks { response } => {
                     let mut blocks = self.state.blocks.clone();
-                    
+
                     self.with_temp_dir(|temp_dir| {
                         for block in blocks.values_mut() {
-                            let _ = inject_block_dir(temp_dir, &block.block_id, &mut block.contents);
+                            let _ =
+                                inject_block_dir(temp_dir, &block.block_id, &mut block.contents);
                         }
                     });
                     let _ = response.send(blocks);
@@ -815,7 +815,7 @@ mod tests {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let db_path = temp_dir.path().join("events.db");
         let event_pool = EventStore::create(db_path.to_str().unwrap()).await.unwrap();
-        
+
         let handle = spawn_engine("test_file".to_string(), event_pool.clone())
             .await
             .expect("Failed to spawn engine");
@@ -846,7 +846,7 @@ mod tests {
         // Verify _block_dir is injected
         let contents = block.contents.as_object().unwrap();
         assert!(contents.contains_key("_block_dir"));
-        
+
         let block_dir = contents.get("_block_dir").unwrap().as_str().unwrap();
         assert!(std::path::Path::new(block_dir).exists());
         assert!(block_dir.contains(block_id));


### PR DESCRIPTION
## 文件修改总结

### 修改目的

实现 `_block_dir` 运行时注入机制，为每个 block 提供独立的文件系统目录，用于存储 block 相关资源（如终端会话文件、代码文件等）。

### 解决的问题

1. Block 文件系统隔离：每个 block 需要独立目录存储资源
2. 事件数据库可移植性：`_block_dir` 是运行时字段，不应持久化到事件存储中
3. 代码复用：统一处理 `_block_dir` 注入逻辑，避免重复

### 主要修改内容

#### 1. 新增 `inject_block_dir` 辅助函数 (第 25-45 行)
```rust
fn inject_block_dir(
    temp_dir: &Path,
    block_id: &str,
    contents: &mut serde_json::Value,
) -> Result<PathBuf, String>
```
- 创建 `block-{block_id}` 目录
- 将目录路径注入到 `contents._block_dir`
- 统一处理目录创建和路径注入

#### 2. GetBlock 消息处理 (第 150-166 行)
- 在返回 block 前注入 `_block_dir`
- 跳过 `:memory:` 数据库（单元测试场景）

#### 3. GetAllBlocks 消息处理 (第 167-183 行)
- 为所有 block 批量注入 `_block_dir`
- 确保查询时所有 block 都包含目录路径

#### 4. process_command 中的处理 (第 264-325 行)
- 步骤 2.5：处理现有 block 时注入 `_block_dir`（第 264-276 行）
- 步骤 5.5：`core.create` 时为新 block 注入 `_block_dir`（第 306-325 行）
- 步骤 7：持久化前移除 `_block_dir`（第 339-348 行）
  - 创建 `events_to_persist` 副本
  - 移除所有 `_block_dir` 字段
  - 仅持久化清理后的版本

### 设计要点

1. 运行时注入：`_block_dir` 仅在运行时存在，不写入事件数据库
2. 测试友好：自动跳过 `:memory:` 数据库，无需文件系统访问
3. 统一处理：使用 `inject_block_dir` 统一处理，减少重复代码
4. 数据分离：运行时数据与持久化数据分离，保持事件数据库可移植性

### 工作流程

```
命令处理流程：
1. 接收命令
2. 获取/创建 block → 注入 _block_dir
3. 授权检查
4. 执行 handler（可使用 _block_dir）
5. 更新向量时钟
6. 特殊处理 core.create → 注入 _block_dir 到新 block
7. 移除 _block_dir → 持久化到数据库
8. 应用事件到状态（保留 _block_dir 供前端使用）
```

该设计在提供文件系统功能的同时，保持了事件数据库的可移植性和一致性。