### PR TITLE
feat: integrate .gitignore parsing into directory import    

### DIFF
--- a/src-tauri/.elfignore
+++ b/src-tauri/.elfignore
@@ -1,0 +1,172 @@
+# Elfiee default ignore patterns
+# This file controls which directories and files are excluded when importing
+# external projects. Syntax is the same as .gitignore.
+#
+# Edit this file to customize the defaults for your environment.
+
+# ── Directories ──────────────────────────────────────
+
+# JavaScript / TypeScript
+node_modules/
+.next/
+.nuxt/
+
+# Rust
+target/
+
+# Python
+__pycache__/
+.venv/
+venv/
+.tox/
+.mypy_cache/
+.pytest_cache/
+
+# Go
+vendor/
+
+# Java / Kotlin / Android
+.gradle/
+.m2/
+
+# iOS / macOS
+Pods/
+
+# .NET / C#
+packages/
+
+# Generic build / output
+dist/
+build/
+out/
+coverage/
+.cache/
+.parcel-cache/
+.turbo/
+
+# ── Binary files ─────────────────────────────────────
+
+# Images
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.ico
+*.icns
+*.bmp
+*.tiff
+*.tif
+*.avif
+*.heic
+*.heif
+*.cur
+*.psd
+*.ai
+*.eps
+*.raw
+*.cr2
+*.nef
+*.dng
+
+# Video
+*.mp4
+*.mov
+*.avi
+*.mkv
+*.wmv
+*.flv
+*.webm
+*.m4v
+
+# Audio
+*.mp3
+*.wav
+*.ogg
+*.flac
+*.aac
+*.m4a
+*.wma
+*.opus
+*.mid
+*.midi
+
+# Archives
+*.pdf
+*.zip
+*.tar
+*.gz
+*.7z
+*.rar
+*.bz2
+*.xz
+*.zst
+*.tgz
+*.cab
+*.dmg
+*.iso
+*.img
+
+# Java / Android archives
+*.jar
+*.war
+*.ear
+*.apk
+*.aab
+
+# Binary / Compiled
+*.exe
+*.dll
+*.so
+*.dylib
+*.bin
+*.obj
+*.o
+*.a
+*.lib
+*.pdb
+*.msi
+*.ipa
+
+# Bytecode
+*.pyc
+*.class
+*.wasm
+
+# Databases
+*.db
+*.sqlite
+*.sqlite3
+
+# Fonts
+*.ttf
+*.otf
+*.woff
+*.woff2
+*.eot
+
+# Office documents (binary formats)
+*.doc
+*.docx
+*.xls
+*.xlsx
+*.ppt
+*.pptx
+*.odt
+*.ods
+*.odp
+
+# Data formats (binary)
+*.parquet
+*.arrow
+*.avro
+*.pb
+
+# 3D / Design
+*.blend
+*.fbx
+*.glb
+*.swf
+
+# OS artifacts
+.DS_Store

--- a/src-tauri/.elftypes
+++ b/src-tauri/.elftypes
@@ -5,60 +5,59 @@
 #
 # Format:
 #   [block_type]
-#   ext1
-#   ext2
+#   .ext1
+#   .ext2
 #
-# Location at runtime: ~/.elf/.elftypes
 # Edit this file to customize the defaults for your environment.
 
 [markdown]
-md
-markdown
+.md
+.markdown
 
 [code]
 # Rust
-rs
+.rs
 # Python
-py
+.py
 # JavaScript / TypeScript
-js
-ts
-jsx
-tsx
+.js
+.ts
+.jsx
+.tsx
 # C / C++
-c
-cpp
-h
-hpp
+.c
+.cpp
+.h
+.hpp
 # JVM
-java
-kt
-scala
+.java
+.kt
+.scala
 # Other languages
-go
-rb
-php
-swift
-cs
+.go
+.rb
+.php
+.swift
+.cs
 # Data / Config
-json
-toml
-yaml
-yml
-xml
-ini
-conf
+.json
+.toml
+.yaml
+.yml
+.xml
+.ini
+.conf
 # Shell
-sh
-bash
-zsh
-fish
+.sh
+.bash
+.zsh
+.fish
 # Web
-html
-htm
-css
-scss
-sass
-less
+.html
+.htm
+.css
+.scss
+.sass
+.less
 # Database
-sql
+.sql

--- a/src-tauri/.elftypes
+++ b/src-tauri/.elftypes
@@ -1,0 +1,64 @@
+# Elfiee file type mappings
+# This file maps file extensions to elf block types.
+# Only extensions listed here will be recognized; unlisted extensions
+# fall back to "code" block type.
+#
+# Format:
+#   [block_type]
+#   ext1
+#   ext2
+#
+# Location at runtime: ~/.elf/.elftypes
+# Edit this file to customize the defaults for your environment.
+
+[markdown]
+md
+markdown
+
+[code]
+# Rust
+rs
+# Python
+py
+# JavaScript / TypeScript
+js
+ts
+jsx
+tsx
+# C / C++
+c
+cpp
+h
+hpp
+# JVM
+java
+kt
+scala
+# Other languages
+go
+rb
+php
+swift
+cs
+# Data / Config
+json
+toml
+yaml
+yml
+xml
+ini
+conf
+# Shell
+sh
+bash
+zsh
+fish
+# Web
+html
+htm
+css
+scss
+sass
+less
+# Database
+sql

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
 zip = "0.6"
 tempfile = "3.8"
 walkdir = "2"
+ignore = "0.4"
 capability-macros = { path = "capability-macros" }
 tokio = { version = "1.36", features = ["full"] }
 dashmap = "5.5"

--- a/src-tauri/src/extensions/directory/fs_scanner.rs
+++ b/src-tauri/src/extensions/directory/fs_scanner.rs
@@ -1,3 +1,4 @@
+use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
 
@@ -31,6 +32,11 @@ pub struct ScanOptions {
     pub follow_symlinks: bool,
     /// Whether to ignore hidden files (starting with dot)
     pub ignore_hidden: bool,
+    /// Directory names to always exclude (applied as highest-priority overrides,
+    /// effective even when no .gitignore exists). Empty by default if you want
+    /// to rely solely on .gitignore; populated with common dependency/build
+    /// directories in `Default` as a safety net.
+    pub ignore_patterns: Vec<String>,
     /// Maximum file size in bytes to include
     pub max_file_size: u64,
     /// Maximum number of files to scan
@@ -45,6 +51,41 @@ impl Default for ScanOptions {
             max_depth: 100,
             follow_symlinks: false,
             ignore_hidden: true,
+            ignore_patterns: vec![
+                // JavaScript / TypeScript
+                "node_modules",
+                ".next",
+                ".nuxt",
+                // Rust
+                "target",
+                // Python
+                "__pycache__",
+                ".venv",
+                "venv",
+                ".tox",
+                ".mypy_cache",
+                ".pytest_cache",
+                // Go
+                "vendor",
+                // Java / Kotlin / Android
+                ".gradle",
+                ".m2",
+                // iOS / macOS
+                "Pods",
+                // .NET / C#
+                "packages",
+                // Generic build / output
+                "dist",
+                "build",
+                "out",
+                "coverage",
+                ".cache",
+                ".parcel-cache",
+                ".turbo",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect(),
             max_file_size: 10 * 1024 * 1024, // 10 MB
             max_files: 10_000,
             use_gitignore: true,
@@ -76,6 +117,20 @@ pub fn scan_directory(root: &Path, options: &ScanOptions) -> Result<Vec<FileInfo
     // Also read .gitignore in non-git directories (no .git folder required)
     if options.use_gitignore {
         builder.add_custom_ignore_filename(".gitignore");
+    }
+
+    // Apply ignore_patterns as highest-priority overrides (effective even without .gitignore)
+    if !options.ignore_patterns.is_empty() {
+        let mut overrides = OverrideBuilder::new(root);
+        for dir in &options.ignore_patterns {
+            overrides
+                .add(&format!("!**/{}", dir))
+                .map_err(|e| format!("Invalid ignore dir '{}': {}", dir, e))?;
+        }
+        let built = overrides
+            .build()
+            .map_err(|e| format!("Failed to build overrides: {}", e))?;
+        builder.overrides(built);
     }
 
     for result in builder.build() {
@@ -166,6 +221,28 @@ mod tests {
 
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].file_name, "visible.txt");
+    }
+
+    #[test]
+    fn test_scan_skips_default_ignore_patterns() {
+        let temp_dir = TempDir::new().unwrap();
+        // Create common dependency directories
+        fs::create_dir(temp_dir.path().join("node_modules")).unwrap();
+        fs::write(temp_dir.path().join("node_modules/pkg.json"), "{}").unwrap();
+        fs::create_dir(temp_dir.path().join("__pycache__")).unwrap();
+        fs::write(temp_dir.path().join("__pycache__/mod.pyc"), "").unwrap();
+        fs::create_dir(temp_dir.path().join("target")).unwrap();
+        fs::write(temp_dir.path().join("target/debug"), "").unwrap();
+        fs::write(temp_dir.path().join("main.rs"), "code").unwrap();
+
+        let options = ScanOptions::default();
+        let files = scan_directory(temp_dir.path(), &options).unwrap();
+
+        let names: Vec<&str> = files.iter().map(|f| f.file_name.as_str()).collect();
+        assert!(names.contains(&"main.rs"));
+        assert!(!names.contains(&"pkg.json"));
+        assert!(!names.contains(&"mod.pyc"));
+        assert!(!names.contains(&"debug"));
     }
 
     #[test]

--- a/src-tauri/src/extensions/directory/fs_scanner.rs
+++ b/src-tauri/src/extensions/directory/fs_scanner.rs
@@ -45,7 +45,7 @@ pub struct ScanOptions {
 }
 
 /// Content of `.elfignore`, bundled at compile time.
-const DEFAULT_ELFIGNORE: &str = include_str!("../../.elfignore");
+const DEFAULT_ELFIGNORE: &str = include_str!("../../../.elfignore");
 
 /// Parse `.elfignore` content into a list of patterns.
 /// Strips comments, empty lines, and trailing slashes.

--- a/src-tauri/src/extensions/directory/fs_scanner.rs
+++ b/src-tauri/src/extensions/directory/fs_scanner.rs
@@ -119,6 +119,9 @@ pub fn scan_directory(root: &Path, options: &ScanOptions) -> Result<Vec<FileInfo
         builder.add_custom_ignore_filename(".gitignore");
     }
 
+    // Support .elfignore files (same glob syntax as .gitignore)
+    builder.add_custom_ignore_filename(".elfignore");
+
     // Apply ignore_patterns as highest-priority overrides (effective even without .gitignore)
     if !options.ignore_patterns.is_empty() {
         let mut overrides = OverrideBuilder::new(root);
@@ -243,6 +246,30 @@ mod tests {
         assert!(!names.contains(&"pkg.json"));
         assert!(!names.contains(&"mod.pyc"));
         assert!(!names.contains(&"debug"));
+    }
+
+    #[test]
+    fn test_scan_respects_elfignore() {
+        let temp_dir = TempDir::new().unwrap();
+        // .elfignore uses the same glob syntax as .gitignore
+        fs::write(temp_dir.path().join(".elfignore"), "secret/\n*.dat\n").unwrap();
+        fs::create_dir(temp_dir.path().join("secret")).unwrap();
+        fs::write(temp_dir.path().join("secret/key.pem"), "private").unwrap();
+        fs::write(temp_dir.path().join("data.dat"), "binary").unwrap();
+        fs::write(temp_dir.path().join("main.rs"), "code").unwrap();
+
+        let options = ScanOptions::default();
+        let files = scan_directory(temp_dir.path(), &options).unwrap();
+
+        let names: Vec<&str> = files
+            .iter()
+            .filter(|f| !f.is_directory)
+            .map(|f| f.file_name.as_str())
+            .collect();
+
+        assert!(names.contains(&"main.rs"));
+        assert!(!names.contains(&"key.pem"));
+        assert!(!names.contains(&"data.dat"));
     }
 
     #[test]

--- a/src-tauri/src/extensions/directory/fs_scanner.rs
+++ b/src-tauri/src/extensions/directory/fs_scanner.rs
@@ -32,10 +32,9 @@ pub struct ScanOptions {
     pub follow_symlinks: bool,
     /// Whether to ignore hidden files (starting with dot)
     pub ignore_hidden: bool,
-    /// Directory names to always exclude (applied as highest-priority overrides,
-    /// effective even when no .gitignore exists). Empty by default if you want
-    /// to rely solely on .gitignore; populated with common dependency/build
-    /// directories in `Default` as a safety net.
+    /// Directory/file patterns to always exclude (applied as highest-priority
+    /// overrides, effective even when no .gitignore exists). Loaded from the
+    /// bundled `.elfignore` at compile time.
     pub ignore_patterns: Vec<String>,
     /// Maximum file size in bytes to include
     pub max_file_size: u64,
@@ -45,47 +44,27 @@ pub struct ScanOptions {
     pub use_gitignore: bool,
 }
 
+/// Content of `.elfignore`, bundled at compile time.
+const DEFAULT_ELFIGNORE: &str = include_str!("../../.elfignore");
+
+/// Parse `.elfignore` content into a list of patterns.
+/// Strips comments, empty lines, and trailing slashes.
+fn parse_elfignore(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(|line| line.trim_end_matches('/').to_string())
+        .collect()
+}
+
 impl Default for ScanOptions {
     fn default() -> Self {
         Self {
             max_depth: 100,
             follow_symlinks: false,
             ignore_hidden: true,
-            ignore_patterns: vec![
-                // JavaScript / TypeScript
-                "node_modules",
-                ".next",
-                ".nuxt",
-                // Rust
-                "target",
-                // Python
-                "__pycache__",
-                ".venv",
-                "venv",
-                ".tox",
-                ".mypy_cache",
-                ".pytest_cache",
-                // Go
-                "vendor",
-                // Java / Kotlin / Android
-                ".gradle",
-                ".m2",
-                // iOS / macOS
-                "Pods",
-                // .NET / C#
-                "packages",
-                // Generic build / output
-                "dist",
-                "build",
-                "out",
-                "coverage",
-                ".cache",
-                ".parcel-cache",
-                ".turbo",
-            ]
-            .into_iter()
-            .map(String::from)
-            .collect(),
+            ignore_patterns: parse_elfignore(DEFAULT_ELFIGNORE),
             max_file_size: 10 * 1024 * 1024, // 10 MB
             max_files: 10_000,
             use_gitignore: true,
@@ -118,9 +97,6 @@ pub fn scan_directory(root: &Path, options: &ScanOptions) -> Result<Vec<FileInfo
     if options.use_gitignore {
         builder.add_custom_ignore_filename(".gitignore");
     }
-
-    // Support .elfignore files (same glob syntax as .gitignore)
-    builder.add_custom_ignore_filename(".elfignore");
 
     // Apply ignore_patterns as highest-priority overrides (effective even without .gitignore)
     if !options.ignore_patterns.is_empty() {
@@ -227,49 +203,53 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_skips_default_ignore_patterns() {
+    fn test_scan_skips_ignore_patterns() {
         let temp_dir = TempDir::new().unwrap();
-        // Create common dependency directories
         fs::create_dir(temp_dir.path().join("node_modules")).unwrap();
         fs::write(temp_dir.path().join("node_modules/pkg.json"), "{}").unwrap();
         fs::create_dir(temp_dir.path().join("__pycache__")).unwrap();
         fs::write(temp_dir.path().join("__pycache__/mod.pyc"), "").unwrap();
-        fs::create_dir(temp_dir.path().join("target")).unwrap();
-        fs::write(temp_dir.path().join("target/debug"), "").unwrap();
         fs::write(temp_dir.path().join("main.rs"), "code").unwrap();
 
-        let options = ScanOptions::default();
+        let options = ScanOptions {
+            ignore_patterns: vec!["node_modules".to_string(), "__pycache__".to_string()],
+            ..Default::default()
+        };
         let files = scan_directory(temp_dir.path(), &options).unwrap();
 
         let names: Vec<&str> = files.iter().map(|f| f.file_name.as_str()).collect();
         assert!(names.contains(&"main.rs"));
         assert!(!names.contains(&"pkg.json"));
         assert!(!names.contains(&"mod.pyc"));
-        assert!(!names.contains(&"debug"));
     }
 
     #[test]
-    fn test_scan_respects_elfignore() {
-        let temp_dir = TempDir::new().unwrap();
-        // .elfignore uses the same glob syntax as .gitignore
-        fs::write(temp_dir.path().join(".elfignore"), "secret/\n*.dat\n").unwrap();
-        fs::create_dir(temp_dir.path().join("secret")).unwrap();
-        fs::write(temp_dir.path().join("secret/key.pem"), "private").unwrap();
-        fs::write(temp_dir.path().join("data.dat"), "binary").unwrap();
-        fs::write(temp_dir.path().join("main.rs"), "code").unwrap();
+    fn test_parse_elfignore() {
+        let content = r#"
+# This is a comment
+node_modules/
+__pycache__/
 
-        let options = ScanOptions::default();
-        let files = scan_directory(temp_dir.path(), &options).unwrap();
+  target
+# Another comment
+  .venv/
+"#;
+        let patterns = parse_elfignore(content);
+        assert_eq!(
+            patterns,
+            vec!["node_modules", "__pycache__", "target", ".venv"]
+        );
+    }
 
-        let names: Vec<&str> = files
-            .iter()
-            .filter(|f| !f.is_directory)
-            .map(|f| f.file_name.as_str())
-            .collect();
-
-        assert!(names.contains(&"main.rs"));
-        assert!(!names.contains(&"key.pem"));
-        assert!(!names.contains(&"data.dat"));
+    #[test]
+    fn test_default_elfignore_contains_expected_patterns() {
+        let patterns = parse_elfignore(DEFAULT_ELFIGNORE);
+        assert!(patterns.contains(&"node_modules".to_string()));
+        assert!(patterns.contains(&"__pycache__".to_string()));
+        assert!(patterns.contains(&"target".to_string()));
+        assert!(patterns.contains(&"*.png".to_string()));
+        assert!(patterns.contains(&"*.exe".to_string()));
+        assert!(patterns.contains(&".DS_Store".to_string()));
     }
 
     #[test]
@@ -316,6 +296,27 @@ mod tests {
         assert!(file_names.contains(&"keep.rs"));
         assert!(!file_names.contains(&"temp.tmp"));
         assert!(!file_names.contains(&"remove.bak"));
+    }
+
+    #[test]
+    fn test_scan_skips_glob_patterns() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join("app.rs"), "code").unwrap();
+        fs::write(temp_dir.path().join("logo.png"), &[0x89, 0x50, 0x4E, 0x47]).unwrap();
+        fs::write(temp_dir.path().join("photo.jpg"), &[0xFF, 0xD8]).unwrap();
+        fs::write(temp_dir.path().join("data.db"), &[0x00]).unwrap();
+
+        let options = ScanOptions {
+            ignore_patterns: vec!["*.png".to_string(), "*.jpg".to_string(), "*.db".to_string()],
+            ..Default::default()
+        };
+        let files = scan_directory(temp_dir.path(), &options).unwrap();
+
+        let names: Vec<&str> = files.iter().map(|f| f.file_name.as_str()).collect();
+        assert!(names.contains(&"app.rs"));
+        assert!(!names.contains(&"logo.png"));
+        assert!(!names.contains(&"photo.jpg"));
+        assert!(!names.contains(&"data.db"));
     }
 
     #[test]

--- a/src-tauri/src/extensions/directory/fs_scanner.rs
+++ b/src-tauri/src/extensions/directory/fs_scanner.rs
@@ -1,5 +1,5 @@
+use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
-use walkdir::WalkDir;
 
 /// Information about a scanned file.
 ///
@@ -31,12 +31,12 @@ pub struct ScanOptions {
     pub follow_symlinks: bool,
     /// Whether to ignore hidden files (starting with dot)
     pub ignore_hidden: bool,
-    /// List of directory names to ignore
-    pub ignore_patterns: Vec<String>,
     /// Maximum file size in bytes to include
     pub max_file_size: u64,
     /// Maximum number of files to scan
     pub max_files: usize,
+    /// Whether to respect .gitignore files when scanning
+    pub use_gitignore: bool,
 }
 
 impl Default for ScanOptions {
@@ -45,59 +45,41 @@ impl Default for ScanOptions {
             max_depth: 100,
             follow_symlinks: false,
             ignore_hidden: true,
-            ignore_patterns: vec![
-                "node_modules".to_string(),
-                ".git".to_string(),
-                "target".to_string(),
-                "dist".to_string(),
-                "build".to_string(),
-                ".DS_Store".to_string(),
-            ],
             max_file_size: 10 * 1024 * 1024, // 10 MB
             max_files: 10_000,
+            use_gitignore: true,
         }
     }
 }
 
-/// Scan a directory and return a list of files.
+/// Scan a directory and return a list of files
 ///
-/// Uses `filter_entry()` to prevent descent into hidden and ignored directories.
-/// Without `filter_entry()`, `continue` only skips the entry from results but
-/// WalkDir still descends into hidden/ignored directories (bug fixed here).
+/// Supports `.gitignore` parsing: when `use_gitignore` is enabled (default),
+/// the scanner reads `.gitignore` files (root + nested) and filters out
+/// matching entries automatically.
 pub fn scan_directory(root: &Path, options: &ScanOptions) -> Result<Vec<FileInfo>, String> {
     let mut files = Vec::new();
     let mut count = 0;
 
-    let ignore_hidden = options.ignore_hidden;
-    let ignore_patterns = options.ignore_patterns.clone();
+    let mut builder = WalkBuilder::new(root);
+    builder.max_depth(Some(options.max_depth));
+    builder.follow_links(options.follow_symlinks);
+    builder.hidden(options.ignore_hidden);
+    builder.max_filesize(Some(options.max_file_size));
 
-    let walker = WalkDir::new(root)
-        .max_depth(options.max_depth)
-        .follow_links(options.follow_symlinks);
+    // .gitignore support
+    builder.git_ignore(options.use_gitignore);
+    builder.git_global(options.use_gitignore);
+    builder.git_exclude(options.use_gitignore);
+    builder.ignore(options.use_gitignore);
 
-    // filter_entry prevents descent into filtered directories.
-    // Depth 0 is the root entry itself — always allow it through since the
-    // caller explicitly chose to scan that path (it may be a hidden dir).
-    for entry in walker.into_iter().filter_entry(move |e| {
-        if e.depth() == 0 {
-            return true;
-        }
+    // Also read .gitignore in non-git directories (no .git folder required)
+    if options.use_gitignore {
+        builder.add_custom_ignore_filename(".gitignore");
+    }
 
-        let name = e.file_name().to_string_lossy();
-
-        // Prevent descent into hidden directories
-        if ignore_hidden && name.starts_with('.') {
-            return false;
-        }
-
-        // Prevent descent into ignored directories
-        if ignore_patterns.iter().any(|p| name == *p) {
-            return false;
-        }
-
-        true
-    }) {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+    for result in builder.build() {
+        let entry = result.map_err(|e| format!("Failed to read directory entry: {}", e))?;
         let path = entry.path();
 
         // Check file count limit
@@ -106,20 +88,9 @@ pub fn scan_directory(root: &Path, options: &ScanOptions) -> Result<Vec<FileInfo
             return Err(format!("Too many files (limit: {})", options.max_files));
         }
 
-        // Skip symlinks (they pass filter_entry but shouldn't be included in results)
-        if entry.path_is_symlink() {
-            continue;
-        }
-
         let metadata = entry
             .metadata()
             .map_err(|e| format!("Failed to read metadata: {}", e))?;
-
-        // Skip large files
-        if metadata.is_file() && metadata.len() > options.max_file_size {
-            log::warn!("Skipping large file: {:?} ({} bytes)", path, metadata.len());
-            continue;
-        }
 
         let relative_path = path
             .strip_prefix(root)
@@ -198,16 +169,72 @@ mod tests {
     }
 
     #[test]
-    fn test_scan_respects_ignore_patterns() {
+    fn test_scan_respects_gitignore() {
         let temp_dir = TempDir::new().unwrap();
-        fs::create_dir(temp_dir.path().join("node_modules")).unwrap();
-        fs::write(temp_dir.path().join("node_modules/package.json"), "{}").unwrap();
-        fs::write(temp_dir.path().join("main.js"), "code").unwrap();
+        // Create a .gitignore that ignores *.log files
+        fs::write(temp_dir.path().join(".gitignore"), "*.log\n").unwrap();
+        fs::write(temp_dir.path().join("app.rs"), "fn main() {}").unwrap();
+        fs::write(temp_dir.path().join("debug.log"), "log content").unwrap();
 
         let options = ScanOptions::default();
         let files = scan_directory(temp_dir.path(), &options).unwrap();
 
+        // .gitignore is hidden (starts with dot) → filtered by ignore_hidden
+        // debug.log is filtered by .gitignore rule
+        // Only app.rs should remain
         assert_eq!(files.len(), 1);
-        assert_eq!(files[0].file_name, "main.js");
+        assert_eq!(files[0].file_name, "app.rs");
+    }
+
+    #[test]
+    fn test_scan_respects_nested_gitignore() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::create_dir(temp_dir.path().join("subdir")).unwrap();
+        // Root .gitignore ignores *.tmp
+        fs::write(temp_dir.path().join(".gitignore"), "*.tmp\n").unwrap();
+        // Nested .gitignore ignores *.bak
+        fs::write(temp_dir.path().join("subdir/.gitignore"), "*.bak\n").unwrap();
+        fs::write(temp_dir.path().join("main.rs"), "code").unwrap();
+        fs::write(temp_dir.path().join("temp.tmp"), "temp").unwrap();
+        fs::write(temp_dir.path().join("subdir/keep.rs"), "code").unwrap();
+        fs::write(temp_dir.path().join("subdir/remove.bak"), "backup").unwrap();
+
+        let options = ScanOptions::default();
+        let files = scan_directory(temp_dir.path(), &options).unwrap();
+
+        let file_names: Vec<&str> = files
+            .iter()
+            .filter(|f| !f.is_directory)
+            .map(|f| f.file_name.as_str())
+            .collect();
+
+        assert!(file_names.contains(&"main.rs"));
+        assert!(file_names.contains(&"keep.rs"));
+        assert!(!file_names.contains(&"temp.tmp"));
+        assert!(!file_names.contains(&"remove.bak"));
+    }
+
+    #[test]
+    fn test_scan_gitignore_disabled() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::write(temp_dir.path().join(".gitignore"), "*.log\n").unwrap();
+        fs::write(temp_dir.path().join("app.rs"), "code").unwrap();
+        fs::write(temp_dir.path().join("debug.log"), "log").unwrap();
+
+        let mut options = ScanOptions::default();
+        options.use_gitignore = false;
+        options.ignore_hidden = false; // so .gitignore file itself is visible
+        let files = scan_directory(temp_dir.path(), &options).unwrap();
+
+        let file_names: Vec<&str> = files
+            .iter()
+            .filter(|f| !f.is_directory)
+            .map(|f| f.file_name.as_str())
+            .collect();
+
+        // With gitignore disabled, debug.log should be present
+        assert!(file_names.contains(&"app.rs"));
+        assert!(file_names.contains(&"debug.log"));
+        assert!(file_names.contains(&".gitignore"));
     }
 }

--- a/src-tauri/src/utils/block_type_inference.rs
+++ b/src-tauri/src/utils/block_type_inference.rs
@@ -10,13 +10,38 @@ pub fn infer_block_type(extension: &str) -> Option<String> {
 
     // 1. Explicit Binary Blacklist - Do NOT import these into DB as text
     match ext.as_str() {
-        "png" | "jpg" | "jpeg" | "gif" | "webp" | "svg" | "ico" | // Images
-        "mp4" | "mov" | "avi" | "mkv" |                          // Video
-        "mp3" | "wav" | "ogg" | "flac" |                         // Audio
-        "pdf" | "zip" | "tar" | "gz" | "7z" | "rar" |            // Archives
-        "exe" | "dll" | "so" | "dylib" | "bin" | "obj" | "o" |   // Binary/Compiled
-        "pyc" | "class" | "wasm" |                               // Bytecode
-        "db" | "sqlite" | "sqlite3" => return None,              // Databases
+        // Images
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "ico" |
+        "icns" | "bmp" | "tiff" | "tif" | "avif" | "heic" | "heif" |
+        "cur" | "psd" | "ai" | "eps" | "raw" | "cr2" | "nef" | "dng" |
+        // Video
+        "mp4" | "mov" | "avi" | "mkv" | "wmv" | "flv" | "webm" | "m4v" |
+        // Audio
+        "mp3" | "wav" | "ogg" | "flac" | "aac" | "m4a" | "wma" | "opus" |
+        "mid" | "midi" |
+        // Archives
+        "pdf" | "zip" | "tar" | "gz" | "7z" | "rar" | "bz2" |
+        "xz" | "zst" | "tgz" | "cab" | "dmg" | "iso" | "img" |
+        // Java/Android archives
+        "jar" | "war" | "ear" | "apk" | "aab" |
+        // Binary/Compiled
+        "exe" | "dll" | "so" | "dylib" | "bin" | "obj" | "o" | "a" |
+        "lib" | "pdb" | "msi" | "ipa" |
+        // Bytecode
+        "pyc" | "class" | "wasm" |
+        // Databases
+        "db" | "sqlite" | "sqlite3" |
+        // Fonts
+        "ttf" | "otf" | "woff" | "woff2" | "eot" |
+        // Office documents (binary formats)
+        "doc" | "docx" | "xls" | "xlsx" | "ppt" | "pptx" |
+        "odt" | "ods" | "odp" |
+        // Data formats (binary)
+        "parquet" | "arrow" | "avro" | "pb" |
+        // 3D/Design
+        "blend" | "fbx" | "glb" | "swf" |
+        // OS artifacts
+        "ds_store" => return None,
         _ => {}
     }
 

--- a/src-tauri/src/utils/block_type_inference.rs
+++ b/src-tauri/src/utils/block_type_inference.rs
@@ -47,13 +47,16 @@ fn load_elftypes() -> HashMap<String, String> {
 /// Format:
 /// ```text
 /// [markdown]
-/// md
-/// markdown
+/// .md
+/// .markdown
 ///
 /// [code]
-/// rs
-/// py
+/// .rs
+/// .py
 /// ```
+///
+/// Leading dots are stripped so that keys match the output of
+/// `Path::extension()` (which returns extensions without the dot).
 fn parse_elftypes(content: &str) -> HashMap<String, String> {
     let mut map = HashMap::new();
     let mut current_type: Option<String> = None;
@@ -66,7 +69,8 @@ fn parse_elftypes(content: &str) -> HashMap<String, String> {
         if line.starts_with('[') && line.ends_with(']') {
             current_type = Some(line[1..line.len() - 1].trim().to_string());
         } else if let Some(ref block_type) = current_type {
-            map.insert(line.to_lowercase(), block_type.clone());
+            let ext = line.strip_prefix('.').unwrap_or(line);
+            map.insert(ext.to_lowercase(), block_type.clone());
         }
     }
     map
@@ -101,14 +105,14 @@ mod tests {
         let content = r#"
 # comment
 [markdown]
-md
-markdown
+.md
+.markdown
 
 [code]
-rs
-py
+.rs
+.py
 # inline comment
-js
+.js
 "#;
         let map = parse_elftypes(content);
         assert_eq!(map.get("md").unwrap(), "markdown");
@@ -121,7 +125,7 @@ js
 
     #[test]
     fn test_parse_elftypes_case_insensitive() {
-        let content = "[markdown]\nMD\n";
+        let content = "[markdown]\n.MD\n";
         let map = parse_elftypes(content);
         assert_eq!(map.get("md").unwrap(), "markdown");
     }
@@ -161,7 +165,7 @@ js
     fn test_load_elftypes_custom_file() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join(".elftypes");
-        fs::write(&path, "[diagram]\nmermaid\ndot\n").unwrap();
+        fs::write(&path, "[diagram]\n.mermaid\n.dot\n").unwrap();
 
         std::env::set_var("ELF_TEST_ELFTYPES_PATH", &path);
         let map = load_elftypes();

--- a/src-tauri/src/utils/block_type_inference.rs
+++ b/src-tauri/src/utils/block_type_inference.rs
@@ -1,100 +1,173 @@
-/// Infer Block Type from file extension.
-///
-/// Strategy:
-/// 1. Known markdown extensions -> "markdown"
-/// 2. Known code/config extensions -> "code"
-/// 3. Known binary extensions (images, executables, etc.) -> None (Skip)
-/// 4. Unknown extensions -> Some("code") (Treat as plain text fallback)
-pub fn infer_block_type(extension: &str) -> Option<String> {
-    let ext = extension.to_lowercase();
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::OnceLock;
 
-    // 1. Explicit Binary Blacklist - Do NOT import these into DB as text
-    match ext.as_str() {
-        // Images
-        "png" | "jpg" | "jpeg" | "gif" | "webp" | "ico" |
-        "icns" | "bmp" | "tiff" | "tif" | "avif" | "heic" | "heif" |
-        "cur" | "psd" | "ai" | "eps" | "raw" | "cr2" | "nef" | "dng" |
-        // Video
-        "mp4" | "mov" | "avi" | "mkv" | "wmv" | "flv" | "webm" | "m4v" |
-        // Audio
-        "mp3" | "wav" | "ogg" | "flac" | "aac" | "m4a" | "wma" | "opus" |
-        "mid" | "midi" |
-        // Archives
-        "pdf" | "zip" | "tar" | "gz" | "7z" | "rar" | "bz2" |
-        "xz" | "zst" | "tgz" | "cab" | "dmg" | "iso" | "img" |
-        // Java/Android archives
-        "jar" | "war" | "ear" | "apk" | "aab" |
-        // Binary/Compiled
-        "exe" | "dll" | "so" | "dylib" | "bin" | "obj" | "o" | "a" |
-        "lib" | "pdb" | "msi" | "ipa" |
-        // Bytecode
-        "pyc" | "class" | "wasm" |
-        // Databases
-        "db" | "sqlite" | "sqlite3" |
-        // Fonts
-        "ttf" | "otf" | "woff" | "woff2" | "eot" |
-        // Office documents (binary formats)
-        "doc" | "docx" | "xls" | "xlsx" | "ppt" | "pptx" |
-        "odt" | "ods" | "odp" |
-        // Data formats (binary)
-        "parquet" | "arrow" | "avro" | "pb" |
-        // 3D/Design
-        "blend" | "fbx" | "glb" | "swf" |
-        // OS artifacts
-        "ds_store" => return None,
-        _ => {}
+/// Default content for `.elftypes`, bundled at compile time.
+const DEFAULT_ELFTYPES: &str = include_str!("../../.elftypes");
+
+/// Cached type map: extension → block_type.
+static TYPE_MAP: OnceLock<HashMap<String, String>> = OnceLock::new();
+
+/// Return the path to the user's `.elftypes` file (`~/.elf/.elftypes`).
+///
+/// Respects `ELF_TEST_ELFTYPES_PATH` for testing.
+fn elftypes_path() -> Option<PathBuf> {
+    if let Ok(test_path) = std::env::var("ELF_TEST_ELFTYPES_PATH") {
+        return Some(PathBuf::from(test_path));
+    }
+    let home = dirs::home_dir()?;
+    Some(home.join(".elf").join(".elftypes"))
+}
+
+/// Load and parse `.elftypes`, auto-creating the file from the bundled
+/// default if it does not exist yet.
+fn load_elftypes() -> HashMap<String, String> {
+    let path = match elftypes_path() {
+        Some(p) => p,
+        None => return parse_elftypes(DEFAULT_ELFTYPES),
+    };
+
+    // Auto-create from bundled default if missing
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(&path, DEFAULT_ELFTYPES);
     }
 
-    // 2. Specific Type Mapping
-    match ext.as_str() {
-        // Markdown
-        "md" | "markdown" => Some("markdown".to_string()),
+    match fs::read_to_string(&path) {
+        Ok(content) => parse_elftypes(&content),
+        Err(_) => parse_elftypes(DEFAULT_ELFTYPES),
+    }
+}
 
-        // Code (Handled by 'code' block type)
-        "rs" | "py" | "js" | "ts" | "jsx" | "tsx" | "c" | "cpp" | "h" | "hpp" | "java" | "go"
-        | "rb" | "php" | "swift" | "kt" | "cs" | "scala" | "json" | "toml" | "yaml" | "yml"
-        | "xml" | "ini" | "conf" | "sh" | "bash" | "zsh" | "fish" | "html" | "htm" | "css"
-        | "scss" | "sass" | "less" | "sql" => Some("code".to_string()),
+/// Parse `.elftypes` content into a `HashMap<extension, block_type>`.
+///
+/// Format:
+/// ```text
+/// [markdown]
+/// md
+/// markdown
+///
+/// [code]
+/// rs
+/// py
+/// ```
+fn parse_elftypes(content: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let mut current_type: Option<String> = None;
 
-        // 3. Fallback: Treat everything else as plain text 'code' block
-        // This ensures we don't miss .env, .gitignore, license files, etc.
-        _ => {
-            log::debug!("Unknown extension '{}', defaulting to code block type", ext);
-            Some("code".to_string())
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
         }
+        if line.starts_with('[') && line.ends_with(']') {
+            current_type = Some(line[1..line.len() - 1].trim().to_string());
+        } else if let Some(ref block_type) = current_type {
+            map.insert(line.to_lowercase(), block_type.clone());
+        }
+    }
+    map
+}
+
+/// Infer Block Type from file extension.
+///
+/// Looks up the extension in the type map loaded from `~/.elf/.elftypes`.
+/// Unknown extensions fall back to `"code"` block type.
+///
+/// Binary files (images, executables, archives, etc.) are filtered out at scan
+/// time via `.elfignore` patterns and never reach this function.
+pub fn infer_block_type(extension: &str) -> Option<String> {
+    let ext = extension.to_lowercase();
+    let map = TYPE_MAP.get_or_init(load_elftypes);
+
+    if let Some(block_type) = map.get(&ext) {
+        Some(block_type.clone())
+    } else {
+        log::debug!("Unknown extension '{}', defaulting to code block type", ext);
+        Some("code".to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
-    fn test_markdown_extensions() {
-        assert_eq!(infer_block_type("md"), Some("markdown".to_string()));
-        assert_eq!(infer_block_type("MD"), Some("markdown".to_string()));
+    fn test_parse_elftypes() {
+        let content = r#"
+# comment
+[markdown]
+md
+markdown
+
+[code]
+rs
+py
+# inline comment
+js
+"#;
+        let map = parse_elftypes(content);
+        assert_eq!(map.get("md").unwrap(), "markdown");
+        assert_eq!(map.get("markdown").unwrap(), "markdown");
+        assert_eq!(map.get("rs").unwrap(), "code");
+        assert_eq!(map.get("py").unwrap(), "code");
+        assert_eq!(map.get("js").unwrap(), "code");
+        assert_eq!(map.get("unknown"), None);
     }
 
     #[test]
-    fn test_known_code_extensions() {
-        assert_eq!(infer_block_type("rs"), Some("code".to_string()));
-        assert_eq!(infer_block_type("json"), Some("code".to_string()));
+    fn test_parse_elftypes_case_insensitive() {
+        let content = "[markdown]\nMD\n";
+        let map = parse_elftypes(content);
+        assert_eq!(map.get("md").unwrap(), "markdown");
     }
 
     #[test]
-    fn test_binary_blacklist() {
-        assert_eq!(infer_block_type("png"), None);
-        assert_eq!(infer_block_type("exe"), None);
-        assert_eq!(infer_block_type("wasm"), None);
-        assert_eq!(infer_block_type("db"), None);
+    fn test_parse_elftypes_empty() {
+        let map = parse_elftypes("");
+        assert!(map.is_empty());
     }
 
     #[test]
-    fn test_fallback_to_code() {
-        // Unknown or missing extensions should be treated as text
-        assert_eq!(infer_block_type("env"), Some("code".to_string()));
-        assert_eq!(infer_block_type("gitignore"), Some("code".to_string()));
-        assert_eq!(infer_block_type("LICENSE"), Some("code".to_string()));
-        assert_eq!(infer_block_type(""), Some("code".to_string()));
+    fn test_bundled_default_contains_expected_entries() {
+        let map = parse_elftypes(DEFAULT_ELFTYPES);
+        assert_eq!(map.get("md").unwrap(), "markdown");
+        assert_eq!(map.get("rs").unwrap(), "code");
+        assert_eq!(map.get("json").unwrap(), "code");
+        assert_eq!(map.get("html").unwrap(), "code");
+    }
+
+    #[test]
+    fn test_load_elftypes_auto_creates_default() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join(".elftypes");
+
+        assert!(!path.exists());
+
+        std::env::set_var("ELF_TEST_ELFTYPES_PATH", &path);
+        let map = load_elftypes();
+        std::env::remove_var("ELF_TEST_ELFTYPES_PATH");
+
+        assert!(path.exists());
+        assert_eq!(map.get("md").unwrap(), "markdown");
+        assert_eq!(map.get("rs").unwrap(), "code");
+    }
+
+    #[test]
+    fn test_load_elftypes_custom_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join(".elftypes");
+        fs::write(&path, "[diagram]\nmermaid\ndot\n").unwrap();
+
+        std::env::set_var("ELF_TEST_ELFTYPES_PATH", &path);
+        let map = load_elftypes();
+        std::env::remove_var("ELF_TEST_ELFTYPES_PATH");
+
+        assert_eq!(map.get("mermaid").unwrap(), "diagram");
+        assert_eq!(map.get("dot").unwrap(), "diagram");
     }
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -3,828 +3,1263 @@
 
 /** user-defined commands **/
 
-
 export const commands = {
-/**
- * Create a new .elf file and open it for editing.
- * 
- * # Arguments
- * * `path` - Absolute path where the new .elf file should be created
- * 
- * # Returns
- * * `Ok(file_id)` - Unique identifier for the opened file
- * * `Err(message)` - Error description if creation fails
- */
-async createFile(path: string) : Promise<Result<string, string>> {
+  /**
+   * Create a new .elf file and open it for editing.
+   *
+   * # Arguments
+   * * `path` - Absolute path where the new .elf file should be created
+   *
+   * # Returns
+   * * `Ok(file_id)` - Unique identifier for the opened file
+   * * `Err(message)` - Error description if creation fails
+   */
+  async createFile(path: string): Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("create_file", { path }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Open an existing .elf file for editing.
- * 
- * # Arguments
- * * `path` - Absolute path to the .elf file to open
- * 
- * # Returns
- * * `Ok(file_id)` - Unique identifier for the opened file
- * * `Err(message)` - Error description if opening fails
- */
-async openFile(path: string) : Promise<Result<string, string>> {
+      return { status: 'ok', data: await TAURI_INVOKE('create_file', { path }) }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Open an existing .elf file for editing.
+   *
+   * # Arguments
+   * * `path` - Absolute path to the .elf file to open
+   *
+   * # Returns
+   * * `Ok(file_id)` - Unique identifier for the opened file
+   * * `Err(message)` - Error description if opening fails
+   */
+  async openFile(path: string): Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("open_file", { path }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Save the current state of a file to disk.
- * 
- * This persists all changes made since the file was opened or last saved.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file to save
- * 
- * # Returns
- * * `Ok(())` - File saved successfully
- * * `Err(message)` - Error description if save fails
- */
-async saveFile(fileId: string) : Promise<Result<null, string>> {
+      return { status: 'ok', data: await TAURI_INVOKE('open_file', { path }) }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Save the current state of a file to disk.
+   *
+   * This persists all changes made since the file was opened or last saved.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file to save
+   *
+   * # Returns
+   * * `Ok(())` - File saved successfully
+   * * `Err(message)` - Error description if save fails
+   */
+  async saveFile(fileId: string): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("save_file", { fileId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Close a file and release associated resources.
- * 
- * This shuts down the engine actor and removes the file from memory.
- * Unsaved changes will be lost.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file to close
- * 
- * # Returns
- * * `Ok(())` - File closed successfully
- * * `Err(message)` - Error description if close fails
- */
-async closeFile(fileId: string) : Promise<Result<null, string>> {
+      return { status: 'ok', data: await TAURI_INVOKE('save_file', { fileId }) }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Close a file and release associated resources.
+   *
+   * This shuts down the engine actor and removes the file from memory.
+   * Unsaved changes will be lost.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file to close
+   *
+   * # Returns
+   * * `Ok(())` - File closed successfully
+   * * `Err(message)` - Error description if close fails
+   */
+  async closeFile(fileId: string): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("close_file", { fileId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get list of all currently open files.
- * 
- * # Returns
- * * `Ok(Vec<file_id>)` - List of file IDs currently open
- * * `Err(message)` - Error description if retrieval fails
- */
-async listOpenFiles() : Promise<Result<string[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('close_file', { fileId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get list of all currently open files.
+   *
+   * # Returns
+   * * `Ok(Vec<file_id>)` - List of file IDs currently open
+   * * `Err(message)` - Error description if retrieval fails
+   */
+  async listOpenFiles(): Promise<Result<string[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("list_open_files") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get all events for a specific file.
- * 
- * This command filters events based on permissions:
- * - Block events: Only returns events for blocks where user has core.read permission
- * - Editor events: Always returned (file-level information, similar to Git collaborators)
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `editor_id` - Optional editor ID (defaults to active editor)
- * 
- * # Returns
- * * `Ok(Vec<Event>)` - List of events the user has permission to view
- * * `Err(message)` - Error description if retrieval fails
- */
-async getAllEvents(fileId: string, editorId: string | null) : Promise<Result<Event[], string>> {
+      return { status: 'ok', data: await TAURI_INVOKE('list_open_files') }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get all events for a specific file.
+   *
+   * This command filters events based on permissions:
+   * - Block events: Only returns events for blocks where user has core.read permission
+   * - Editor events: Always returned (file-level information, similar to Git collaborators)
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `editor_id` - Optional editor ID (defaults to active editor)
+   *
+   * # Returns
+   * * `Ok(Vec<Event>)` - List of events the user has permission to view
+   * * `Err(message)` - Error description if retrieval fails
+   */
+  async getAllEvents(
+    fileId: string,
+    editorId: string | null
+  ): Promise<Result<Event[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_all_events", { fileId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get detailed information about a file.
- * 
- * Returns metadata including file name, path, collaborators (editors),
- * and timestamps. The file must be open to retrieve this information.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * 
- * # Returns
- * * `Ok(FileMetadata)` - File metadata
- * * `Err(message)` - Error description if retrieval fails
- */
-async getFileInfo(fileId: string) : Promise<Result<FileMetadata, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_all_events', { fileId, editorId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get detailed information about a file.
+   *
+   * Returns metadata including file name, path, collaborators (editors),
+   * and timestamps. The file must be open to retrieve this information.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   *
+   * # Returns
+   * * `Ok(FileMetadata)` - File metadata
+   * * `Err(message)` - Error description if retrieval fails
+   */
+  async getFileInfo(fileId: string): Promise<Result<FileMetadata, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_file_info", { fileId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Rename a file on the filesystem.
- * 
- * This updates the file path both in the filesystem and in the application state.
- * The file must be open to be renamed.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `new_name` - New name for the file (without extension)
- * 
- * # Returns
- * * `Ok(())` - File renamed successfully
- * * `Err(message)` - Error description if rename fails
- */
-async renameFile(fileId: string, newName: string) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_file_info', { fileId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Rename a file on the filesystem.
+   *
+   * This updates the file path both in the filesystem and in the application state.
+   * The file must be open to be renamed.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `new_name` - New name for the file (without extension)
+   *
+   * # Returns
+   * * `Ok(())` - File renamed successfully
+   * * `Err(message)` - Error description if rename fails
+   */
+  async renameFile(
+    fileId: string,
+    newName: string
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("rename_file", { fileId, newName }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Duplicate (copy) an existing .elf file.
- * 
- * This creates a copy of the file with a new name and opens it for editing.
- * The new file will have " Copy" appended to the name, or " Copy N" if that name exists.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file to duplicate
- * 
- * # Returns
- * * `Ok(new_file_id)` - Unique identifier for the newly created duplicate file
- * * `Err(message)` - Error description if duplication fails
- */
-async duplicateFile(fileId: string) : Promise<Result<string, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('rename_file', { fileId, newName }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Duplicate (copy) an existing .elf file.
+   *
+   * This creates a copy of the file with a new name and opens it for editing.
+   * The new file will have " Copy" appended to the name, or " Copy N" if that name exists.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file to duplicate
+   *
+   * # Returns
+   * * `Ok(new_file_id)` - Unique identifier for the newly created duplicate file
+   * * `Err(message)` - Error description if duplication fails
+   */
+  async duplicateFile(fileId: string): Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("duplicate_file", { fileId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get the global system editor ID from config.
- * 
- * This returns the persistent system editor ID that is stored in
- * the user's home directory config file (`$USER_HOME/.elf/config.json`).
- * 
- * # Returns
- * * `Ok(String)` - The system editor ID (UUID)
- * * `Err(message)` - Error if config cannot be read
- */
-async getSystemEditorIdFromConfig() : Promise<Result<string, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('duplicate_file', { fileId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get the global system editor ID from config.
+   *
+   * This returns the persistent system editor ID that is stored in
+   * the user's home directory config file (`$USER_HOME/.elf/config.json`).
+   *
+   * # Returns
+   * * `Ok(String)` - The system editor ID (UUID)
+   * * `Err(message)` - Error if config cannot be read
+   */
+  async getSystemEditorIdFromConfig(): Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_system_editor_id_from_config") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get the full state snapshot (block + grants) at a specific event.
- */
-async getStateAtEvent(fileId: string, blockId: string, eventId: string) : Promise<Result<StateSnapshot, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_system_editor_id_from_config'),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get the full state snapshot (block + grants) at a specific event.
+   */
+  async getStateAtEvent(
+    fileId: string,
+    blockId: string,
+    eventId: string
+  ): Promise<Result<StateSnapshot, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_state_at_event", { fileId, blockId, eventId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Execute a command on a block in the specified file.
- * 
- * This is the primary way to modify blocks. Commands are processed by the engine actor,
- * which handles authorization, execution, and persistence.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file containing the block
- * * `cmd` - Command to execute (create, delete, link, write, etc.)
- * 
- * # Returns
- * * `Ok(events)` - Events generated by the command execution
- * * `Err(message)` - Error description if execution fails
- */
-async executeCommand(fileId: string, cmd: Command) : Promise<Result<Event[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_state_at_event', {
+          fileId,
+          blockId,
+          eventId,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Execute a command on a block in the specified file.
+   *
+   * This is the primary way to modify blocks. Commands are processed by the engine actor,
+   * which handles authorization, execution, and persistence.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file containing the block
+   * * `cmd` - Command to execute (create, delete, link, write, etc.)
+   *
+   * # Returns
+   * * `Ok(events)` - Events generated by the command execution
+   * * `Err(message)` - Error description if execution fails
+   */
+  async executeCommand(
+    fileId: string,
+    cmd: Command
+  ): Promise<Result<Event[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("execute_command", { fileId, cmd }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get a specific block by ID from a file.
- * 
- * This command checks read permission before returning the block content.
- * The permission check uses the capability system (CBAC):
- * - markdown blocks require `markdown.read` permission
- * - code blocks require `code.read` permission
- * - directory blocks require `directory.read` permission
- * 
- * Block owners always have read permission.
- * Other editors need explicit grants in the grants table.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file containing the block
- * * `block_id` - Unique identifier of the block to retrieve
- * * `editor_id` - Optional editor ID (defaults to active editor)
- * 
- * # Returns
- * * `Ok(block)` - The requested block (if authorized)
- * * `Err(message)` - Error if file not open, block not found, or no read permission
- */
-async getBlock(fileId: string, blockId: string, editorId: string | null) : Promise<Result<Block, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('execute_command', { fileId, cmd }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get a specific block by ID from a file.
+   *
+   * This command checks read permission before returning the block content.
+   * The permission check uses the capability system (CBAC):
+   * - markdown blocks require `markdown.read` permission
+   * - code blocks require `code.read` permission
+   * - directory blocks require `directory.read` permission
+   *
+   * Block owners always have read permission.
+   * Other editors need explicit grants in the grants table.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file containing the block
+   * * `block_id` - Unique identifier of the block to retrieve
+   * * `editor_id` - Optional editor ID (defaults to active editor)
+   *
+   * # Returns
+   * * `Ok(block)` - The requested block (if authorized)
+   * * `Err(message)` - Error if file not open, block not found, or no read permission
+   */
+  async getBlock(
+    fileId: string,
+    blockId: string,
+    editorId: string | null
+  ): Promise<Result<Block, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_block", { fileId, blockId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get all blocks from a file.
- * 
- * This command filters blocks based on permissions:
- * - Only returns blocks where the user is owner OR has core.read OR has any other permission
- * - For directory blocks with directory.read permission, returns full contents
- * - For directory blocks without directory.read but with other permissions, returns empty entries
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `editor_id` - Optional editor ID (defaults to active editor)
- * 
- * # Returns
- * * `Ok(blocks)` - Vector of blocks the user has permission to view
- * * `Err(message)` - Error if file is not open
- */
-async getAllBlocks(fileId: string, editorId: string | null) : Promise<Result<Block[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_block', { fileId, blockId, editorId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get all blocks from a file.
+   *
+   * This command filters blocks based on permissions:
+   * - Only returns blocks where the user is owner OR has core.read OR has any other permission
+   * - For directory blocks with directory.read permission, returns full contents
+   * - For directory blocks without directory.read but with other permissions, returns empty entries
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `editor_id` - Optional editor ID (defaults to active editor)
+   *
+   * # Returns
+   * * `Ok(blocks)` - Vector of blocks the user has permission to view
+   * * `Err(message)` - Error if file is not open
+   */
+  async getAllBlocks(
+    fileId: string,
+    editorId: string | null
+  ): Promise<Result<Block[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_all_blocks", { fileId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Update block metadata.
- * 
- * This generates a Command with core.update_metadata capability and processes it through
- * the engine actor. The metadata is merged with existing metadata and updated via event replay.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file containing the block
- * * `block_id` - Unique identifier of the block to update
- * * `metadata` - Metadata fields to update (will be merged with existing metadata)
- * 
- * # Returns
- * * `Ok(())` - Metadata updated successfully
- * * `Err(message)` - Error description if update fails
- */
-async updateBlockMetadata(fileId: string, blockId: string, metadata: JsonValue) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_all_blocks', { fileId, editorId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Update block metadata.
+   *
+   * This generates a Command with core.update_metadata capability and processes it through
+   * the engine actor. The metadata is merged with existing metadata and updated via event replay.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file containing the block
+   * * `block_id` - Unique identifier of the block to update
+   * * `metadata` - Metadata fields to update (will be merged with existing metadata)
+   *
+   * # Returns
+   * * `Ok(())` - Metadata updated successfully
+   * * `Err(message)` - Error description if update fails
+   */
+  async updateBlockMetadata(
+    fileId: string,
+    blockId: string,
+    metadata: JsonValue
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("update_block_metadata", { fileId, blockId, metadata }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Rename a block.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `block_id` - Unique identifier of the block
- * * `name` - New name for the block
- */
-async renameBlock(fileId: string, blockId: string, name: string) : Promise<Result<Event[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('update_block_metadata', {
+          fileId,
+          blockId,
+          metadata,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Rename a block.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `block_id` - Unique identifier of the block
+   * * `name` - New name for the block
+   */
+  async renameBlock(
+    fileId: string,
+    blockId: string,
+    name: string
+  ): Promise<Result<Event[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("rename_block", { fileId, blockId, name }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Change the type of a block.
- * 
- * This command provides smart type changing with automatic inference from file extensions.
- * It wraps the core.change_type capability with additional convenience features.
- * 
- * # Type Inference Logic
- * 1. If `block_type` is provided, use it directly
- * 2. If `file_extension` is provided, use `infer_block_type()` to determine type
- * 3. If both are provided, `block_type` takes precedence
- * 4. If neither is provided, returns an error
- * 
- * # Use Cases
- * - User explicitly selects new type via UI: pass `block_type`
- * - After file rename with extension change: pass `file_extension` for auto-inference
- * - Direct type conversion: pass `block_type` with exact type string
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `block_id` - Unique identifier of the block
- * * `block_type` - Optional: directly specify the new block type
- * * `file_extension` - Optional: file extension to infer type from (e.g., "md", "rs", "txt")
- * 
- * # Returns
- * * `Ok(events)` - Events generated by the type change
- * * `Err(message)` - Error if inference fails or parameters are invalid
- * 
- * # Examples
- * 
- * Direct type specification:
- * ```rust,no_run
- * use tauri::State;
- * use elfiee_lib::state::AppState;
- * use elfiee_lib::commands::block::change_block_type;
- * 
- * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
- * change_block_type(
- * "file_123".to_string(),
- * "block_456".to_string(),
- * Some("markdown".to_string()),
- * None,
- * state
- * ).await?;
- * # Ok(())
- * # }
- * ```
- * 
- * Infer type from extension:
- * ```rust,no_run
- * use tauri::State;
- * use elfiee_lib::state::AppState;
- * use elfiee_lib::commands::block::change_block_type;
- * 
- * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
- * change_block_type(
- * "file_123".to_string(),
- * "block_456".to_string(),
- * None,
- * Some("md".to_string()),
- * state
- * ).await?;
- * # Ok(())
- * # }
- * ```
- */
-async changeBlockType(fileId: string, blockId: string, blockType: string | null, fileExtension: string | null) : Promise<Result<Event[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('rename_block', { fileId, blockId, name }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Change the type of a block.
+   *
+   * This command provides smart type changing with automatic inference from file extensions.
+   * It wraps the core.change_type capability with additional convenience features.
+   *
+   * # Type Inference Logic
+   * 1. If `block_type` is provided, use it directly
+   * 2. If `file_extension` is provided, use `infer_block_type()` to determine type
+   * 3. If both are provided, `block_type` takes precedence
+   * 4. If neither is provided, returns an error
+   *
+   * # Use Cases
+   * - User explicitly selects new type via UI: pass `block_type`
+   * - After file rename with extension change: pass `file_extension` for auto-inference
+   * - Direct type conversion: pass `block_type` with exact type string
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `block_id` - Unique identifier of the block
+   * * `block_type` - Optional: directly specify the new block type
+   * * `file_extension` - Optional: file extension to infer type from (e.g., "md", "rs", "txt")
+   *
+   * # Returns
+   * * `Ok(events)` - Events generated by the type change
+   * * `Err(message)` - Error if inference fails or parameters are invalid
+   *
+   * # Examples
+   *
+   * Direct type specification:
+   * ```rust,no_run
+   * use tauri::State;
+   * use elfiee_lib::state::AppState;
+   * use elfiee_lib::commands::block::change_block_type;
+   *
+   * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
+   * change_block_type(
+   * "file_123".to_string(),
+   * "block_456".to_string(),
+   * Some("markdown".to_string()),
+   * None,
+   * state
+   * ).await?;
+   * # Ok(())
+   * # }
+   * ```
+   *
+   * Infer type from extension:
+   * ```rust,no_run
+   * use tauri::State;
+   * use elfiee_lib::state::AppState;
+   * use elfiee_lib::commands::block::change_block_type;
+   *
+   * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
+   * change_block_type(
+   * "file_123".to_string(),
+   * "block_456".to_string(),
+   * None,
+   * Some("md".to_string()),
+   * state
+   * ).await?;
+   * # Ok(())
+   * # }
+   * ```
+   */
+  async changeBlockType(
+    fileId: string,
+    blockId: string,
+    blockType: string | null,
+    fileExtension: string | null
+  ): Promise<Result<Event[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("change_block_type", { fileId, blockId, blockType, fileExtension }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Check if current editor has permission for a capability on a block.
- */
-async checkPermission(fileId: string, blockId: string, capability: string, editorId: string | null) : Promise<Result<boolean, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('change_block_type', {
+          fileId,
+          blockId,
+          blockType,
+          fileExtension,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Check if current editor has permission for a capability on a block.
+   */
+  async checkPermission(
+    fileId: string,
+    blockId: string,
+    capability: string,
+    editorId: string | null
+  ): Promise<Result<boolean, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("check_permission", { fileId, blockId, capability, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Create a new editor for the specified file.
- * 
- * This generates a Command with editor.create capability and processes it through
- * the engine actor. The new editor is added to the file's state via event replay.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `name` - Display name for the new editor
- * * `editor_type` - Optional editor type (Human or Bot)
- * * `block_id` - Optional block ID. If provided, only the block owner can create editors.
- * 
- * # Returns
- * * `Ok(Editor)` - The newly created editor
- * * `Err(message)` - Error description if creation fails
- */
-async createEditor(fileId: string, name: string, editorType: string | null, blockId: string | null) : Promise<Result<Editor, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('check_permission', {
+          fileId,
+          blockId,
+          capability,
+          editorId,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Create a new editor for the specified file.
+   *
+   * This generates a Command with editor.create capability and processes it through
+   * the engine actor. The new editor is added to the file's state via event replay.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `name` - Display name for the new editor
+   * * `editor_type` - Optional editor type (Human or Bot)
+   * * `block_id` - Optional block ID. If provided, only the block owner can create editors.
+   *
+   * # Returns
+   * * `Ok(Editor)` - The newly created editor
+   * * `Err(message)` - Error description if creation fails
+   */
+  async createEditor(
+    fileId: string,
+    name: string,
+    editorType: string | null,
+    blockId: string | null
+  ): Promise<Result<Editor, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("create_editor", { fileId, name, editorType, blockId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Delete an editor identity from the specified file.
- * 
- * This generates a Command with editor.delete capability and processes it through
- * the engine actor. The editor and associated grants are removed from the state.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `editor_id` - Unique identifier of the editor to delete
- * * `block_id` - Optional block ID. If provided, only the block owner can delete editors.
- * 
- * # Returns
- * * `Ok(())` - Success
- * * `Err(message)` - Error description if deletion fails
- */
-async deleteEditor(fileId: string, editorId: string, blockId: string | null) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('create_editor', {
+          fileId,
+          name,
+          editorType,
+          blockId,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Delete an editor identity from the specified file.
+   *
+   * This generates a Command with editor.delete capability and processes it through
+   * the engine actor. The editor and associated grants are removed from the state.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `editor_id` - Unique identifier of the editor to delete
+   * * `block_id` - Optional block ID. If provided, only the block owner can delete editors.
+   *
+   * # Returns
+   * * `Ok(())` - Success
+   * * `Err(message)` - Error description if deletion fails
+   */
+  async deleteEditor(
+    fileId: string,
+    editorId: string,
+    blockId: string | null
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("delete_editor", { fileId, editorId, blockId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * List all editors for the specified file.
- * 
- * Reads the editors from the StateProjector which is built from event replay.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * 
- * # Returns
- * * `Ok(Vec<Editor>)` - List of all editors
- * * `Err(message)` - Error if file is not open
- */
-async listEditors(fileId: string) : Promise<Result<Editor[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('delete_editor', {
+          fileId,
+          editorId,
+          blockId,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * List all editors for the specified file.
+   *
+   * Reads the editors from the StateProjector which is built from event replay.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   *
+   * # Returns
+   * * `Ok(Vec<Editor>)` - List of all editors
+   * * `Err(message)` - Error if file is not open
+   */
+  async listEditors(fileId: string): Promise<Result<Editor[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("list_editors", { fileId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get a specific editor by ID.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `editor_id` - Unique identifier of the editor
- * 
- * # Returns
- * * `Ok(Editor)` - The requested editor
- * * `Err(message)` - Error if file not open or editor not found
- */
-async getEditor(fileId: string, editorId: string) : Promise<Result<Editor, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('list_editors', { fileId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get a specific editor by ID.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `editor_id` - Unique identifier of the editor
+   *
+   * # Returns
+   * * `Ok(Editor)` - The requested editor
+   * * `Err(message)` - Error if file not open or editor not found
+   */
+  async getEditor(
+    fileId: string,
+    editorId: string
+  ): Promise<Result<Editor, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_editor", { fileId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Set the active editor for the specified file.
- * 
- * This is a UI state operation and is not persisted to the .elf file.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `editor_id` - Unique identifier of the editor to set as active
- * 
- * # Returns
- * * `Ok(())` - Success
- * * `Err(message)` - Error if file or editor not found
- */
-async setActiveEditor(fileId: string, editorId: string) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_editor', { fileId, editorId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Set the active editor for the specified file.
+   *
+   * This is a UI state operation and is not persisted to the .elf file.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `editor_id` - Unique identifier of the editor to set as active
+   *
+   * # Returns
+   * * `Ok(())` - Success
+   * * `Err(message)` - Error if file or editor not found
+   */
+  async setActiveEditor(
+    fileId: string,
+    editorId: string
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("set_active_editor", { fileId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get the currently active editor for the specified file.
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * 
- * # Returns
- * * `Ok(Option<String>)` - Editor ID if one is active, None otherwise
- * * `Err(message)` - Error if file is not open
- */
-async getActiveEditor(fileId: string) : Promise<Result<string | null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('set_active_editor', { fileId, editorId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get the currently active editor for the specified file.
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   *
+   * # Returns
+   * * `Ok(Option<String>)` - Editor ID if one is active, None otherwise
+   * * `Err(message)` - Error if file is not open
+   */
+  async getActiveEditor(
+    fileId: string
+  ): Promise<Result<string | null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_active_editor", { fileId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * List all grants for the specified file.
- * 
- * This command filters grants based on permissions:
- * - Only returns grants for blocks where the user has core.read permission
- * - Wildcard grants (*) are always included as they are file-level
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `editor_id` - Optional editor ID (defaults to active editor)
- * 
- * # Returns
- * * `Ok(Vec<Grant>)` - List of grants the user has permission to view
- * * `Err(message)` - Error if file is not open
- */
-async listGrants(fileId: string, editorId: string | null) : Promise<Result<Grant[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_active_editor', { fileId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * List all grants for the specified file.
+   *
+   * This command filters grants based on permissions:
+   * - Only returns grants for blocks where the user has core.read permission
+   * - Wildcard grants (*) are always included as they are file-level
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `editor_id` - Optional editor ID (defaults to active editor)
+   *
+   * # Returns
+   * * `Ok(Vec<Grant>)` - List of grants the user has permission to view
+   * * `Err(message)` - Error if file is not open
+   */
+  async listGrants(
+    fileId: string,
+    editorId: string | null
+  ): Promise<Result<Grant[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("list_grants", { fileId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Get grants for a specific block.
- * 
- * Returns all grants that apply to this block (including wildcard grants).
- * 
- * # Arguments
- * * `file_id` - Unique identifier of the file
- * * `block_id` - Unique identifier of the block
- * 
- * # Returns
- * * `Ok(Vec<Grant>)` - List of grants for the block
- * * `Err(message)` - Error if file is not open
- */
-async getBlockGrants(fileId: string, blockId: string) : Promise<Result<Grant[], string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('list_grants', { fileId, editorId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Get grants for a specific block.
+   *
+   * Returns all grants that apply to this block (including wildcard grants).
+   *
+   * # Arguments
+   * * `file_id` - Unique identifier of the file
+   * * `block_id` - Unique identifier of the block
+   *
+   * # Returns
+   * * `Ok(Vec<Grant>)` - List of grants for the block
+   * * `Err(message)` - Error if file is not open
+   */
+  async getBlockGrants(
+    fileId: string,
+    blockId: string
+  ): Promise<Result<Grant[], string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_block_grants", { fileId, blockId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Materialize blocks to the external file system (Checkout).
- * 
- * This command implements the bottom-layer I/O ability:
- * 1. Calls the `directory.export` capability for authorization and auditing.
- * 2. If authorized, performs the 'checkout' by writing block contents to the target path.
- */
-async checkoutWorkspace(fileId: string, blockId: string, payload: DirectoryExportPayload) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('get_block_grants', { fileId, blockId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Materialize blocks to the external file system (Checkout).
+   */
+  async checkoutWorkspace(
+    fileId: string,
+    blockId: string,
+    payload: DirectoryExportPayload
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("checkout_workspace", { fileId, blockId, payload }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Execute a task commit: validate → auto-discover repo → export snapshots → git commit.
- * 
- * This command follows the Split Pattern:
- * 1. Calls task.commit capability handler (authorization + audit event)
- * 2. Auto-discovers linked repo from downstream blocks
- * 3. Verifies discovered path has .git
- * 4. Copies downstream block snapshots to repo path
- * 5. Executes git branch + add + commit flow
- * 
- * # Arguments
- * * `file_id` - Elf file containing the task block
- * * `task_block_id` - The task block to commit
- * * `editor_id` - Optional editor ID (defaults to active editor)
- */
-async commitTask(fileId: string, taskBlockId: string, editorId: string | null) : Promise<Result<TaskCommitResult, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('checkout_workspace', {
+          fileId,
+          blockId,
+          payload,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Execute a task commit (Tauri command wrapper).
+   */
+  async commitTask(
+    fileId: string,
+    taskBlockId: string,
+    editorId: string | null
+  ): Promise<Result<TaskCommitResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("commit_task", { fileId, taskBlockId, editorId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Inject git hooks into a linked repository (commit protect ON).
- * 
- * Hooks are stored in the .elf temp dir, so they disappear on crash/close.
- * Sets `core.hooksPath` to block direct commits and require task.commit workflow.
- * 
- * # Arguments
- * * `file_id` - Elf file ID (used to locate temp dir)
- * * `repo_path` - External project git repo root
- */
-async injectHooksForRepo(fileId: string, repoPath: string) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('commit_task', {
+          fileId,
+          taskBlockId,
+          editorId,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Inject git hooks into a linked repository (commit protect ON).
+   *
+   * Hooks are stored in the .elf temp dir, so they disappear on crash/close.
+   * Sets `core.hooksPath` to block direct commits and require task.commit workflow.
+   * Hook content is read from the .elf/ block (event sourced).
+   */
+  async injectHooksForRepo(
+    fileId: string,
+    repoPath: string
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("inject_hooks_for_repo", { fileId, repoPath }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Remove git hooks from a linked repository (commit protect OFF).
- * 
- * Restores original `core.hooksPath` and cleans up Elfiee hook files.
- */
-async removeHooksForRepo(fileId: string, repoPath: string) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('inject_hooks_for_repo', { fileId, repoPath }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Remove git hooks from a linked repository (commit protect OFF).
+   *
+   * Restores original `core.hooksPath` and cleans up Elfiee hook files.
+   */
+  async removeHooksForRepo(
+    fileId: string,
+    repoPath: string
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("remove_hooks_for_repo", { fileId, repoPath }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Check if git hooks are currently injected for a repo.
- */
-async isHooksActive(fileId: string, repoPath: string) : Promise<Result<boolean, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('remove_hooks_for_repo', { fileId, repoPath }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Check if git hooks are currently injected for a repo.
+   */
+  async isHooksActive(
+    fileId: string,
+    repoPath: string
+  ): Promise<Result<boolean, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("is_hooks_active", { fileId, repoPath }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Initialize and create a new PTY session.
- * 
- * This command:
- * 1. Creates a PTY using pure functions from utils/pty.rs
- * 2. Spawns a shell process
- * 3. Starts a reader thread to forward PTY output to the frontend
- * 4. Stores the session in TerminalState
- * 
- * Note: The terminal.init capability should be called separately via
- * execute_command to record the session_started event.
- * 
- * # Arguments
- * * `app` - Tauri app handle for emitting events
- * * `state` - Terminal state containing active sessions
- * * `block_id` - The terminal block ID
- * * `cols` - Number of columns
- * * `rows` - Number of rows
- * * `cwd` - Optional working directory
- * 
- * # Returns
- * * `Ok(())` - Session created successfully
- * * `Err(String)` - Error if creation fails
- */
-async initPtySession(blockId: string, cols: number, rows: number, cwd: string | null) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('is_hooks_active', { fileId, repoPath }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Initialize and create a new PTY session.
+   *
+   * This command:
+   * 1. Creates a PTY using pure functions from utils/pty.rs
+   * 2. Spawns a shell process
+   * 3. Starts a reader thread to forward PTY output to the frontend
+   * 4. Stores the session in TerminalState
+   *
+   * Note: The terminal.init capability should be called separately via
+   * execute_command to record the session_started event.
+   *
+   * # Arguments
+   * * `app` - Tauri app handle for emitting events
+   * * `state` - Terminal state containing active sessions
+   * * `block_id` - The terminal block ID
+   * * `cols` - Number of columns
+   * * `rows` - Number of rows
+   * * `cwd` - Optional working directory
+   *
+   * # Returns
+   * * `Ok(())` - Session created successfully
+   * * `Err(String)` - Error if creation fails
+   */
+  async initPtySession(
+    blockId: string,
+    cols: number,
+    rows: number,
+    cwd: string | null
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("init_pty_session", { blockId, cols, rows, cwd }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Write data to the PTY.
- * 
- * This command forwards user input from the frontend terminal (xterm.js)
- * to the backend PTY process.
- * 
- * **Note**: This is a high-frequency operation (called on every keystroke).
- * No capability check is performed for performance reasons.
- * Authorization was already checked during session initialization.
- * 
- * # Arguments
- * * `state` - Terminal state containing active sessions
- * * `block_id` - The terminal block ID
- * * `data` - The data to write (user input)
- * 
- * # Returns
- * * `Ok(())` - Data written successfully
- * * `Err(String)` - Error if session not found or write fails
- */
-async writeToPty(blockId: string, data: string) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('init_pty_session', {
+          blockId,
+          cols,
+          rows,
+          cwd,
+        }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Write data to the PTY.
+   *
+   * This command forwards user input from the frontend terminal (xterm.js)
+   * to the backend PTY process.
+   *
+   * **Note**: This is a high-frequency operation (called on every keystroke).
+   * No capability check is performed for performance reasons.
+   * Authorization was already checked during session initialization.
+   *
+   * # Arguments
+   * * `state` - Terminal state containing active sessions
+   * * `block_id` - The terminal block ID
+   * * `data` - The data to write (user input)
+   *
+   * # Returns
+   * * `Ok(())` - Data written successfully
+   * * `Err(String)` - Error if session not found or write fails
+   */
+  async writeToPty(
+    blockId: string,
+    data: string
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("write_to_pty", { blockId, data }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Resize the PTY.
- * 
- * This command updates the PTY window dimensions when the frontend
- * terminal viewport changes size.
- * 
- * **Note**: This is a high-frequency operation (called on window resize).
- * No capability check is performed for performance reasons.
- * Authorization was already checked during session initialization.
- * 
- * # Arguments
- * * `state` - Terminal state containing active sessions
- * * `block_id` - The terminal block ID
- * * `cols` - New number of columns
- * * `rows` - New number of rows
- * 
- * # Returns
- * * `Ok(())` - PTY resized successfully
- * * `Err(String)` - Error if session not found or resize fails
- */
-async resizePty(blockId: string, cols: number, rows: number) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('write_to_pty', { blockId, data }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Resize the PTY.
+   *
+   * This command updates the PTY window dimensions when the frontend
+   * terminal viewport changes size.
+   *
+   * **Note**: This is a high-frequency operation (called on window resize).
+   * No capability check is performed for performance reasons.
+   * Authorization was already checked during session initialization.
+   *
+   * # Arguments
+   * * `state` - Terminal state containing active sessions
+   * * `block_id` - The terminal block ID
+   * * `cols` - New number of columns
+   * * `rows` - New number of rows
+   *
+   * # Returns
+   * * `Ok(())` - PTY resized successfully
+   * * `Err(String)` - Error if session not found or resize fails
+   */
+  async resizePty(
+    blockId: string,
+    cols: number,
+    rows: number
+  ): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("resize_pty", { blockId, cols, rows }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/**
- * Close a PTY session.
- * 
- * This command removes the session from state and drops the PTY resources.
- * When the session is dropped, the reader thread receives EOF and exits naturally.
- * 
- * Note: The terminal.close capability should be called separately via
- * execute_command to record the session_closed event.
- * 
- * # Arguments
- * * `state` - Terminal state containing active sessions
- * * `block_id` - The terminal block ID
- * 
- * # Returns
- * * `Ok(())` - Session closed successfully (or was already closed)
- * * `Err(String)` - Error if operation fails
- */
-async closePtySession(blockId: string) : Promise<Result<null, string>> {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('resize_pty', { blockId, cols, rows }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Close a PTY session.
+   *
+   * This command removes the session from state and drops the PTY resources.
+   * When the session is dropped, the reader thread receives EOF and exits naturally.
+   *
+   * Note: The terminal.close capability should be called separately via
+   * execute_command to record the session_closed event.
+   *
+   * # Arguments
+   * * `state` - Terminal state containing active sessions
+   * * `block_id` - The terminal block ID
+   *
+   * # Returns
+   * * `Ok(())` - Session closed successfully (or was already closed)
+   * * `Err(String)` - Error if operation fails
+   */
+  async closePtySession(blockId: string): Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("close_pty_session", { blockId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-}
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('close_pty_session', { blockId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Create an Agent Block bound to a .claude/ directory and auto-enable it.
+   */
+  async agentCreate(
+    fileId: string,
+    payload: AgentCreatePayload
+  ): Promise<Result<AgentCreateResult, string>> {
+    try {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('agent_create', { fileId, payload }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Enable an Agent Block: recreate symlink and inject MCP config.
+   */
+  async agentEnable(
+    fileId: string,
+    agentBlockId: string
+  ): Promise<Result<AgentEnableResult, string>> {
+    try {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('agent_enable', { fileId, agentBlockId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
+  /**
+   * Disable an Agent Block: remove symlink and MCP config.
+   */
+  async agentDisable(
+    fileId: string,
+    agentBlockId: string
+  ): Promise<Result<AgentDisableResult, string>> {
+    try {
+      return {
+        status: 'ok',
+        data: await TAURI_INVOKE('agent_disable', { fileId, agentBlockId }),
+      }
+    } catch (e) {
+      if (e instanceof Error) throw e
+      else return { status: 'error', error: e as any }
+    }
+  },
 }
 
 /** user-defined events **/
 
-
+export const events = __makeEvents__<{
+  ptyOutputEvent: PtyOutputEvent
+  stateChangedEvent: StateChangedEvent
+}>({
+  ptyOutputEvent: 'pty-output-event',
+  stateChangedEvent: 'state-changed-event',
+})
 
 /** user-defined constants **/
-
-
 
 /** user-defined types **/
 
 /**
+ * Agent Block contents, storing per-AI-tool integration config.
+ *
+ * Stored in `Block.contents`.
+ *
+ * Key change from V1: binds to `config_dir` (absolute path) instead of Dir Block ID.
+ * `editor_id` is now required (not optional).
+ */
+export type AgentContents = {
+  /**
+   * Agent display name (default: "elfiee")
+   */
+  name: string
+  /**
+   * AI tool provider identifier.
+   *
+   * Examples: "claude_code", "cursor", "windsurf"
+   * Used to determine provider-specific behavior (symlink paths, MCP config format, etc.)
+   */
+  provider?: string
+  /**
+   * Absolute path to the AI tool's config directory this agent is bound to.
+   *
+   * Examples:
+   * - Claude Code: "/home/user/repo-a/.claude"
+   * - Cursor: "/home/user/repo-a/.cursor"
+   *
+   * Used to derive:
+   * - Symlink target: `{config_dir}/skills/elfiee-client/`
+   * - MCP config locations: `{config_dir.parent()}/.mcp.json` + `{config_dir}/mcp.json`
+   */
+  config_dir: string
+  /**
+   * Agent current status
+   */
+  status: AgentStatus
+  /**
+   * Bot editor_id associated with this agent (required).
+   * Used by per-agent MCP server to attribute operations to the correct identity.
+   */
+  editor_id: string
+}
+/**
+ * Payload for agent.create capability
+ */
+export type AgentCreatePayload = {
+  /**
+   * Agent display name (optional, default: "elfiee")
+   */
+  name?: string | null
+  /**
+   * AI tool provider identifier (optional, default: "claude_code")
+   */
+  provider?: string
+  /**
+   * Absolute path to the AI tool's config directory (required)
+   */
+  config_dir: string
+  /**
+   * Bot editor_id to associate with this agent.
+   * If not provided, the command layer auto-creates a bot editor.
+   */
+  editor_id?: string | null
+}
+/**
+ * Result type for agent.create Tauri command
+ */
+export type AgentCreateResult = {
+  /**
+   * Created Agent Block ID
+   */
+  agent_block_id: string
+  /**
+   * Agent status after creation
+   */
+  status: AgentStatus
+  /**
+   * Whether the user needs to restart Claude Code
+   */
+  needs_restart: boolean
+  /**
+   * Human-readable message
+   */
+  message: string
+}
+/**
+ * Payload for agent.disable capability
+ */
+export type AgentDisablePayload = {
+  /**
+   * Agent Block ID (required)
+   */
+  agent_block_id: string
+}
+/**
+ * Result type for agent.disable Tauri command
+ */
+export type AgentDisableResult = {
+  /**
+   * Agent Block ID
+   */
+  agent_block_id: string
+  /**
+   * Agent status after disable
+   */
+  status: AgentStatus
+  /**
+   * Human-readable message
+   */
+  message: string
+  /**
+   * Warnings for partial failures
+   */
+  warnings: string[]
+}
+/**
+ * Payload for agent.enable capability
+ */
+export type AgentEnablePayload = {
+  /**
+   * Agent Block ID (required)
+   */
+  agent_block_id: string
+}
+/**
+ * Result type for agent.enable Tauri command
+ */
+export type AgentEnableResult = {
+  /**
+   * Agent Block ID
+   */
+  agent_block_id: string
+  /**
+   * Agent status after enable
+   */
+  status: AgentStatus
+  /**
+   * Whether the user needs to restart Claude Code
+   */
+  needs_restart: boolean
+  /**
+   * Human-readable message
+   */
+  message: string
+  /**
+   * Warnings for partial failures (e.g. symlink OK but MCP config failed)
+   */
+  warnings: string[]
+}
+/**
+ * Agent enable/disable status
+ */
+export type AgentStatus =
+  /**
+   * Enabled: symlink exists, MCP config injected, MCP server running
+   */
+  | 'enabled'
+  /**
+   * Disabled: symlink cleaned, MCP config removed, MCP server stopped
+   */
+  | 'disabled'
+/**
  * Block 是 Elfiee 的基本内容单元。
- * 
+ *
  * `children` 字段存储逻辑因果关系图（Logical Causal Graph），
  * key 仅允许 `RELATION_IMPLEMENT`（即 `"implement"`），
  * value 为下游 block_id 列表。
  */
-export type Block = { block_id: string; name: string; block_type: string; contents: JsonValue; children: Partial<{ [key in string]: string[] }>; owner: string; 
-/**
- * Block metadata with timestamps and custom fields
- */
-metadata: BlockMetadata }
+export type Block = {
+  block_id: string
+  name: string
+  block_type: string
+  contents: JsonValue
+  children: Partial<{ [key in string]: string[] }>
+  owner: string
+  /**
+   * Block metadata with timestamps and custom fields
+   */
+  metadata: BlockMetadata
+}
 /**
  * Block metadata structure (recommended format)
- * 
+ *
  * Stored in Block.metadata field (JSON format).
  * This structure defines the recommended metadata format, but is not enforced.
- * 
+ *
  * # Fields
  * * `description` - Detailed description of the block
  * * `created_at` - Creation timestamp (ISO 8601 UTC format, e.g., "2025-12-17T02:30:00Z")
  * * `updated_at` - Last update timestamp (ISO 8601 UTC format)
  * * `custom` - Custom extension fields (merged into root object via #[serde(flatten)])
  */
-export type BlockMetadata = 
-/**
- * Custom extension fields
- */
-(Partial<{ [key in string]: null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }> }>) & { 
-/**
- * Block description
- */
-description?: string | null; 
-/**
- * Creation timestamp (ISO 8601 UTC)
- */
-created_at?: string | null; 
-/**
- * Last update timestamp (ISO 8601 UTC)
- */
-updated_at?: string | null }
+export type BlockMetadata =
+  /**
+   * Custom extension fields
+   */
+  Partial<{
+    [key in string]:
+      | null
+      | boolean
+      | number
+      | string
+      | JsonValue[]
+      | Partial<{ [key in string]: JsonValue }>
+  }> & {
+    /**
+     * Block description
+     */
+    description?: string | null
+    /**
+     * Creation timestamp (ISO 8601 UTC)
+     */
+    created_at?: string | null
+    /**
+     * Last update timestamp (ISO 8601 UTC)
+     */
+    updated_at?: string | null
+  }
 /**
  * Payload for CodeRead
  */
@@ -832,45 +1267,65 @@ export type CodeReadPayload = Record<string, never>
 /**
  * Payload for CodeWrite
  */
-export type CodeWritePayload = { 
-/**
- * The source code text content to write
- */
-content: string }
-export type Command = { cmd_id: string; editor_id: string; cap_id: string; block_id: string; payload: JsonValue; 
-/**
- * UTC timestamp when the command was created (timezone-aware)
- */
-timestamp: string }
+export type CodeWritePayload = {
+  /**
+   * The source code text content to write
+   */
+  content: string
+}
+export type Command = {
+  cmd_id: string
+  editor_id: string
+  cap_id: string
+  block_id: string
+  payload: JsonValue
+  /**
+   * UTC timestamp when the command was created (timezone-aware)
+   */
+  timestamp: string
+}
 /**
  * Payload for core.create capability
- * 
+ *
  * This payload is used to create a new block with a name and type.
  */
-export type CreateBlockPayload = { 
-/**
- * The display name for the new block
- */
-name: string; 
-/**
- * The block type (e.g., "markdown", "code", "diagram")
- */
-block_type: string; 
-/**
- * The source category of the block ("outline" or "linked")
- */
-source?: string; 
-/**
- * Optional metadata (description, custom fields, etc.)
- * 
- * If provided, will be merged with auto-generated timestamps.
- * Example: { "description": "项目需求文档" }
- */
-metadata?: JsonValue | null }
+export type CreateBlockPayload = {
+  /**
+   * The display name for the new block
+   */
+  name: string
+  /**
+   * The block type (e.g., "markdown", "code", "diagram")
+   */
+  block_type: string
+  /**
+   * The source category of the block ("outline" or "linked")
+   */
+  source?: string
+  /**
+   * Optional metadata (description, custom fields, etc.)
+   *
+   * If provided, will be merged with auto-generated timestamps.
+   * Example: { "description": "项目需求文档" }
+   */
+  metadata?: JsonValue | null
+}
 /**
  * Payload for DirectoryCreate
  */
-export type DirectoryCreatePayload = { path: string; type: string; source: string; content?: string | null; block_type?: string | null }
+export type DirectoryCreatePayload = {
+  path: string
+  type: string
+  source: string
+  content?: string | null
+  block_type?: string | null
+  /**
+   * Optional: Link an existing block instead of creating a new one.
+   * When provided (and entry_type is "file"), skips core.create and
+   * registers the existing block_id in the directory index.
+   */
+  existing_block_id?: string | null
+}
 /**
  * Payload for DirectoryDelete
  */
@@ -878,178 +1333,245 @@ export type DirectoryDeletePayload = { path: string }
 /**
  * Payload for DirectoryExport
  */
-export type DirectoryExportPayload = { target_path: string; source_path?: string | null }
+export type DirectoryExportPayload = {
+  target_path: string
+  source_path?: string | null
+}
 /**
  * Payload for DirectoryImport
  */
-export type DirectoryImportPayload = { source_path: string; target_path?: string | null }
+export type DirectoryImportPayload = {
+  source_path: string
+  target_path?: string | null
+}
 /**
  * Payload for DirectoryRename
  */
 export type DirectoryRenamePayload = { old_path: string; new_path: string }
 /**
  * Payload for DirectoryRenameWithTypeChange
- * 
+ *
  * Atomically renames a file entry and changes its block type in a single transaction.
  * This ensures consistency when file extension changes require block type updates.
  */
-export type DirectoryRenameWithTypeChangePayload = { old_path: string; new_path: string; 
-/**
- * Optional: Directly specify the new block type (e.g., "markdown", "code")
- */
-block_type?: string | null; 
-/**
- * Optional: Infer block type from file extension (e.g., "md", "rs", "txt")
- */
-file_extension?: string | null }
+export type DirectoryRenameWithTypeChangePayload = {
+  old_path: string
+  new_path: string
+  /**
+   * Optional: Directly specify the new block type (e.g., "markdown", "code")
+   */
+  block_type?: string | null
+  /**
+   * Optional: Infer block type from file extension (e.g., "md", "rs", "txt")
+   */
+  file_extension?: string | null
+}
 /**
  * Payload for directory.write capability.
- * 
+ *
  * Used to directly update the entries map of a directory block.
  */
-export type DirectoryWritePayload = { 
-/**
- * The full entries map to be saved
- */
-entries: JsonValue; 
-/**
- * The source category of this directory block ("outline" or "linked")
- */
-source?: string | null }
-export type Editor = { editor_id: string; name: string; editor_type?: EditorType }
+export type DirectoryWritePayload = {
+  /**
+   * The full entries map to be saved
+   */
+  entries: JsonValue
+  /**
+   * The source category of this directory block ("outline" or "linked")
+   */
+  source?: string | null
+}
+export type Editor = {
+  editor_id: string
+  name: string
+  editor_type?: EditorType
+}
 /**
  * Payload for editor.create capability
- * 
+ *
  * This payload is used to create a new editor identity in the file.
  */
-export type EditorCreatePayload = { 
-/**
- * The display name for the new editor
- */
-name: string; 
-/**
- * The type of editor (Human or Bot), defaults to Human if not specified
- */
-editor_type?: string | null; 
-/**
- * Optional explicitly provided editor ID (e.g. system editor ID)
- */
-editor_id?: string | null }
+export type EditorCreatePayload = {
+  /**
+   * The display name for the new editor
+   */
+  name: string
+  /**
+   * The type of editor (Human or Bot), defaults to Human if not specified
+   */
+  editor_type?: string | null
+  /**
+   * Optional explicitly provided editor ID (e.g. system editor ID)
+   */
+  editor_id?: string | null
+}
 /**
  * Payload for editor.delete capability
- * 
+ *
  * This payload is used to delete an editor identity from the file.
  */
-export type EditorDeletePayload = { 
-/**
- * The editor ID to delete
- */
-editor_id: string }
-export type EditorType = "Human" | "Bot"
-export type Event = { event_id: string; entity: string; attribute: string; value: JsonValue; timestamp: Partial<{ [key in string]: number }>; created_at: string }
+export type EditorDeletePayload = {
+  /**
+   * The editor ID to delete
+   */
+  editor_id: string
+}
+export type EditorType = 'Human' | 'Bot'
+export type Event = {
+  event_id: string
+  entity: string
+  attribute: string
+  value: JsonValue
+  timestamp: Partial<{ [key in string]: number }>
+  created_at: string
+}
 /**
  * File metadata for frontend display.
- * 
+ *
  * This structure contains all information about a file that the UI needs to display,
  * including the file name, path, collaborators (editors), and timestamps.
  */
-export type FileMetadata = { file_id: string; name: string; path: string; collaborators: string[]; created_at: string; updated_at: string }
+export type FileMetadata = {
+  file_id: string
+  name: string
+  path: string
+  collaborators: string[]
+  created_at: string
+  updated_at: string
+}
 /**
  * Represents a capability grant in the CBAC system.
- * 
+ *
  * Grants define which editors have which capabilities on which blocks.
  * They are projected from grant/revoke events in the EventStore.
  */
-export type Grant = { 
-/**
- * The editor who has been granted the capability
- */
-editor_id: string; 
-/**
- * The capability that has been granted (e.g., "markdown.write", "core.delete")
- */
-cap_id: string; 
-/**
- * The target block ID, or "*" for wildcard (all blocks)
- */
-block_id: string }
+export type Grant = {
+  /**
+   * The editor who has been granted the capability
+   */
+  editor_id: string
+  /**
+   * The capability that has been granted (e.g., "markdown.write", "core.delete")
+   */
+  cap_id: string
+  /**
+   * The target block ID, or "*" for wildcard (all blocks)
+   */
+  block_id: string
+}
 /**
  * Payload for core.grant capability
- * 
+ *
  * This payload is used to grant a capability to an editor for a specific block.
  */
-export type GrantPayload = { 
-/**
- * The editor ID to grant the capability to
- */
-target_editor: string; 
-/**
- * The capability ID to grant (e.g., "markdown.write", "core.delete")
- */
-capability: string; 
-/**
- * The block ID to grant access to, or "*" for all blocks (wildcard)
- */
-target_block?: string }
-export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
+export type GrantPayload = {
+  /**
+   * The editor ID to grant the capability to
+   */
+  target_editor: string
+  /**
+   * The capability ID to grant (e.g., "markdown.write", "core.delete")
+   */
+  capability: string
+  /**
+   * The block ID to grant access to, or "*" for all blocks (wildcard)
+   */
+  target_block?: string
+}
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | Partial<{ [key in string]: JsonValue }>
 /**
  * Payload for core.link capability
- * 
+ *
  * This payload is used to create a link (relation) from one block to another.
  */
-export type LinkBlockPayload = { 
-/**
- * The relation type (must be "implement")
- */
-relation: string; 
-/**
- * The target block ID to link to
- */
-target_id: string }
+export type LinkBlockPayload = {
+  /**
+   * The relation type (must be "implement")
+   */
+  relation: string
+  /**
+   * The target block ID to link to
+   */
+  target_id: string
+}
 /**
  * Payload for markdown.write capability
- * 
+ *
  * This payload is used to write markdown content to a markdown block.
  * The content is stored directly as a string in the block's contents.markdown field.
  */
-export type MarkdownWritePayload = { 
+export type MarkdownWritePayload = {
+  /**
+   * The markdown content to write to the block
+   */
+  content: string
+}
 /**
- * The markdown content to write to the block
+ * Emitted when PTY produces output (high-frequency, from reader thread).
+ *
+ * The frontend terminal (xterm.js) decodes the base64 data and writes it to the screen.
+ * Only emitted by GUI-initiated PTY sessions (not MCP-initiated sessions which
+ * only write to the output buffer).
  */
-content: string }
+export type PtyOutputEvent = {
+  /**
+   * Base64 encoded output data
+   */
+  data: string
+  /**
+   * The terminal block ID
+   */
+  block_id: string
+}
 /**
  * Payload for core.revoke capability
- * 
+ *
  * This payload is used to revoke a capability from an editor for a specific block.
  */
-export type RevokePayload = { 
+export type RevokePayload = {
+  /**
+   * The editor ID to revoke the capability from
+   */
+  target_editor: string
+  /**
+   * The capability ID to revoke
+   */
+  capability: string
+  /**
+   * The block ID to revoke access from, or "*" for all blocks (wildcard)
+   */
+  target_block?: string
+}
 /**
- * The editor ID to revoke the capability from
+ * Emitted when backend state changes (e.g., blocks modified via MCP or Tauri commands).
+ *
+ * The frontend auto-refreshes blocks, grants, and events for the affected file.
+ * Sent through the `state_changed_tx` broadcast channel by both Tauri commands
+ * and the MCP server after successful command processing.
  */
-target_editor: string; 
-/**
- * The capability ID to revoke
- */
-capability: string; 
-/**
- * The block ID to revoke access from, or "*" for all blocks (wildcard)
- */
-target_block?: string }
+export type StateChangedEvent = { file_id: string }
 /**
  * Full state snapshot at a specific point in time.
  */
-export type StateSnapshot = { 
-/**
- * Block state at that event
- */
-block: Block; 
-/**
- * All grants in the system at that event
- */
-grants: Grant[] }
+export type StateSnapshot = {
+  /**
+   * Block state at that event
+   */
+  block: Block
+  /**
+   * All grants in the system at that event
+   */
+  grants: Grant[]
+}
 /**
  * Payload for task.commit capability
- * 
+ *
  * Empty payload — target repo is auto-discovered from downstream blocks'
  * `_block_dir` metadata, which links to external git repositories.
  */
@@ -1057,179 +1579,186 @@ export type TaskCommitPayload = Record<string, never>
 /**
  * Result of a task.commit operation.
  */
-export type TaskCommitResult = { 
-/**
- * Git commit hash
- */
-commit_hash: string; 
-/**
- * Git branch name
- */
-branch_name: string; 
-/**
- * List of exported file paths
- */
-exported_files: string[] }
+export type TaskCommitResult = {
+  /**
+   * Git commit hash
+   */
+  commit_hash: string
+  /**
+   * Git branch name
+   */
+  branch_name: string
+  /**
+   * List of exported file paths
+   */
+  exported_files: string[]
+}
 /**
  * Payload for task.read capability
- * 
+ *
  * task.read is a permission-only capability, similar to markdown.read.
  * No payload fields needed — the empty JSON object `{}` is accepted.
  */
 export type TaskReadPayload = Record<string, never>
 /**
  * Payload for task.write capability
- * 
+ *
  * Contains markdown content for a task block.
  * Stored in `contents` as `{ "markdown": "..." }` — same model as markdown blocks.
  * Title is stored in `block.name`, description in `metadata.description`.
  */
-export type TaskWritePayload = { 
-/**
- * Markdown 内容
- */
-content: string }
+export type TaskWritePayload = {
+  /**
+   * Markdown 内容
+   */
+  content: string
+}
 /**
  * Payload for terminal.execute capability
- * 
+ *
  * This payload records a command execution in the terminal for audit/history.
  */
-export type TerminalExecutePayload = { 
-/**
- * The command string that was executed
- */
-command: string; 
-/**
- * Exit code of the command (if available)
- */
-exit_code: number | null }
+export type TerminalExecutePayload = {
+  /**
+   * The command string that was executed
+   */
+  command: string
+  /**
+   * Exit code of the command (if available)
+   */
+  exit_code: number | null
+}
 /**
  * Payload for terminal.init capability
- * 
+ *
  * This payload is used to initialize a PTY session for a terminal block.
  */
-export type TerminalInitPayload = { 
-/**
- * Number of columns in the terminal
- */
-cols: number; 
-/**
- * Number of rows in the terminal
- */
-rows: number; 
-/**
- * The terminal block ID
- */
-block_id: string; 
-/**
- * The editor initiating the session
- */
-editor_id: string; 
-/**
- * The file containing the terminal block (required for permission checking)
- */
-file_id: string; 
-/**
- * Optional initial working directory
- */
-cwd: string | null }
+export type TerminalInitPayload = {
+  /**
+   * Number of columns in the terminal
+   */
+  cols: number
+  /**
+   * Number of rows in the terminal
+   */
+  rows: number
+  /**
+   * The terminal block ID
+   */
+  block_id: string
+  /**
+   * The editor initiating the session
+   */
+  editor_id: string
+  /**
+   * The file containing the terminal block (required for permission checking)
+   */
+  file_id: string
+  /**
+   * Optional initial working directory
+   */
+  cwd: string | null
+}
 /**
  * Payload for terminal.save capability
- * 
+ *
  * This payload is used to save terminal content (buffer snapshot) to a terminal block.
  */
-export type TerminalSavePayload = { 
-/**
- * The terminal content to save (typically from xterm.js buffer)
- */
-saved_content: string; 
-/**
- * Timestamp when the content was saved (ISO 8601 format)
- */
-saved_at: string }
+export type TerminalSavePayload = {
+  /**
+   * The terminal content to save (typically from xterm.js buffer)
+   */
+  saved_content: string
+  /**
+   * Timestamp when the content was saved (ISO 8601 format)
+   */
+  saved_at: string
+}
 /**
  * Payload for core.unlink capability
- * 
+ *
  * This payload is used to remove a link (relation) from one block to another.
  */
-export type UnlinkBlockPayload = { 
-/**
- * The relation type (must be "implement")
- */
-relation: string; 
-/**
- * The target block ID to unlink
- */
-target_id: string }
+export type UnlinkBlockPayload = {
+  /**
+   * The relation type (must be "implement")
+   */
+  relation: string
+  /**
+   * The target block ID to unlink
+   */
+  target_id: string
+}
 /**
  * Payload for core.update_metadata capability
- * 
+ *
  * This payload is used to update metadata fields of an existing block.
  * The metadata will be merged with existing metadata (not replaced).
  */
-export type UpdateMetadataPayload = { 
-/**
- * Metadata fields to update or add
- * Example: { "description": "Updated description", "tags": ["tag1", "tag2"] }
- */
-metadata: JsonValue }
+export type UpdateMetadataPayload = {
+  /**
+   * Metadata fields to update or add
+   * Example: { "description": "Updated description", "tags": ["tag1", "tag2"] }
+   */
+  metadata: JsonValue
+}
 
 /** tauri-specta globals **/
 
 import {
-	invoke as TAURI_INVOKE,
-	Channel as TAURI_CHANNEL,
-} from "@tauri-apps/api/core";
-import * as TAURI_API_EVENT from "@tauri-apps/api/event";
-import { type WebviewWindow as __WebviewWindow__ } from "@tauri-apps/api/webviewWindow";
+  invoke as TAURI_INVOKE,
+  Channel as TAURI_CHANNEL,
+} from '@tauri-apps/api/core'
+import * as TAURI_API_EVENT from '@tauri-apps/api/event'
+import { type WebviewWindow as __WebviewWindow__ } from '@tauri-apps/api/webviewWindow'
 
 type __EventObj__<T> = {
-	listen: (
-		cb: TAURI_API_EVENT.EventCallback<T>,
-	) => ReturnType<typeof TAURI_API_EVENT.listen<T>>;
-	once: (
-		cb: TAURI_API_EVENT.EventCallback<T>,
-	) => ReturnType<typeof TAURI_API_EVENT.once<T>>;
-	emit: null extends T
-		? (payload?: T) => ReturnType<typeof TAURI_API_EVENT.emit>
-		: (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>;
-};
+  listen: (
+    cb: TAURI_API_EVENT.EventCallback<T>
+  ) => ReturnType<typeof TAURI_API_EVENT.listen<T>>
+  once: (
+    cb: TAURI_API_EVENT.EventCallback<T>
+  ) => ReturnType<typeof TAURI_API_EVENT.once<T>>
+  emit: null extends T
+    ? (payload?: T) => ReturnType<typeof TAURI_API_EVENT.emit>
+    : (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>
+}
 
 export type Result<T, E> =
-	| { status: "ok"; data: T }
-	| { status: "error"; error: E };
+  | { status: 'ok'; data: T }
+  | { status: 'error'; error: E }
 
 function __makeEvents__<T extends Record<string, any>>(
-	mappings: Record<keyof T, string>,
+  mappings: Record<keyof T, string>
 ) {
-	return new Proxy(
-		{} as unknown as {
-			[K in keyof T]: __EventObj__<T[K]> & {
-				(handle: __WebviewWindow__): __EventObj__<T[K]>;
-			};
-		},
-		{
-			get: (_, event) => {
-				const name = mappings[event as keyof T];
+  return new Proxy(
+    {} as unknown as {
+      [K in keyof T]: __EventObj__<T[K]> & {
+        (handle: __WebviewWindow__): __EventObj__<T[K]>
+      }
+    },
+    {
+      get: (_, event) => {
+        const name = mappings[event as keyof T]
 
-				return new Proxy((() => {}) as any, {
-					apply: (_, __, [window]: [__WebviewWindow__]) => ({
-						listen: (arg: any) => window.listen(name, arg),
-						once: (arg: any) => window.once(name, arg),
-						emit: (arg: any) => window.emit(name, arg),
-					}),
-					get: (_, command: keyof __EventObj__<any>) => {
-						switch (command) {
-							case "listen":
-								return (arg: any) => TAURI_API_EVENT.listen(name, arg);
-							case "once":
-								return (arg: any) => TAURI_API_EVENT.once(name, arg);
-							case "emit":
-								return (arg: any) => TAURI_API_EVENT.emit(name, arg);
-						}
-					},
-				});
-			},
-		},
-	);
+        return new Proxy((() => {}) as any, {
+          apply: (_, __, [window]: [__WebviewWindow__]) => ({
+            listen: (arg: any) => window.listen(name, arg),
+            once: (arg: any) => window.once(name, arg),
+            emit: (arg: any) => window.emit(name, arg),
+          }),
+          get: (_, command: keyof __EventObj__<any>) => {
+            switch (command) {
+              case 'listen':
+                return (arg: any) => TAURI_API_EVENT.listen(name, arg)
+              case 'once':
+                return (arg: any) => TAURI_API_EVENT.once(name, arg)
+              case 'emit':
+                return (arg: any) => TAURI_API_EVENT.emit(name, arg)
+            }
+          },
+        })
+      },
+    }
+  )
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -3,1263 +3,828 @@
 
 /** user-defined commands **/
 
+
 export const commands = {
-  /**
-   * Create a new .elf file and open it for editing.
-   *
-   * # Arguments
-   * * `path` - Absolute path where the new .elf file should be created
-   *
-   * # Returns
-   * * `Ok(file_id)` - Unique identifier for the opened file
-   * * `Err(message)` - Error description if creation fails
-   */
-  async createFile(path: string): Promise<Result<string, string>> {
+/**
+ * Create a new .elf file and open it for editing.
+ * 
+ * # Arguments
+ * * `path` - Absolute path where the new .elf file should be created
+ * 
+ * # Returns
+ * * `Ok(file_id)` - Unique identifier for the opened file
+ * * `Err(message)` - Error description if creation fails
+ */
+async createFile(path: string) : Promise<Result<string, string>> {
     try {
-      return { status: 'ok', data: await TAURI_INVOKE('create_file', { path }) }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Open an existing .elf file for editing.
-   *
-   * # Arguments
-   * * `path` - Absolute path to the .elf file to open
-   *
-   * # Returns
-   * * `Ok(file_id)` - Unique identifier for the opened file
-   * * `Err(message)` - Error description if opening fails
-   */
-  async openFile(path: string): Promise<Result<string, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("create_file", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Open an existing .elf file for editing.
+ * 
+ * # Arguments
+ * * `path` - Absolute path to the .elf file to open
+ * 
+ * # Returns
+ * * `Ok(file_id)` - Unique identifier for the opened file
+ * * `Err(message)` - Error description if opening fails
+ */
+async openFile(path: string) : Promise<Result<string, string>> {
     try {
-      return { status: 'ok', data: await TAURI_INVOKE('open_file', { path }) }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Save the current state of a file to disk.
-   *
-   * This persists all changes made since the file was opened or last saved.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file to save
-   *
-   * # Returns
-   * * `Ok(())` - File saved successfully
-   * * `Err(message)` - Error description if save fails
-   */
-  async saveFile(fileId: string): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("open_file", { path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Save the current state of a file to disk.
+ * 
+ * This persists all changes made since the file was opened or last saved.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file to save
+ * 
+ * # Returns
+ * * `Ok(())` - File saved successfully
+ * * `Err(message)` - Error description if save fails
+ */
+async saveFile(fileId: string) : Promise<Result<null, string>> {
     try {
-      return { status: 'ok', data: await TAURI_INVOKE('save_file', { fileId }) }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Close a file and release associated resources.
-   *
-   * This shuts down the engine actor and removes the file from memory.
-   * Unsaved changes will be lost.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file to close
-   *
-   * # Returns
-   * * `Ok(())` - File closed successfully
-   * * `Err(message)` - Error description if close fails
-   */
-  async closeFile(fileId: string): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("save_file", { fileId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Close a file and release associated resources.
+ * 
+ * This shuts down the engine actor and removes the file from memory.
+ * Unsaved changes will be lost.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file to close
+ * 
+ * # Returns
+ * * `Ok(())` - File closed successfully
+ * * `Err(message)` - Error description if close fails
+ */
+async closeFile(fileId: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('close_file', { fileId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get list of all currently open files.
-   *
-   * # Returns
-   * * `Ok(Vec<file_id>)` - List of file IDs currently open
-   * * `Err(message)` - Error description if retrieval fails
-   */
-  async listOpenFiles(): Promise<Result<string[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("close_file", { fileId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get list of all currently open files.
+ * 
+ * # Returns
+ * * `Ok(Vec<file_id>)` - List of file IDs currently open
+ * * `Err(message)` - Error description if retrieval fails
+ */
+async listOpenFiles() : Promise<Result<string[], string>> {
     try {
-      return { status: 'ok', data: await TAURI_INVOKE('list_open_files') }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get all events for a specific file.
-   *
-   * This command filters events based on permissions:
-   * - Block events: Only returns events for blocks where user has core.read permission
-   * - Editor events: Always returned (file-level information, similar to Git collaborators)
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `editor_id` - Optional editor ID (defaults to active editor)
-   *
-   * # Returns
-   * * `Ok(Vec<Event>)` - List of events the user has permission to view
-   * * `Err(message)` - Error description if retrieval fails
-   */
-  async getAllEvents(
-    fileId: string,
-    editorId: string | null
-  ): Promise<Result<Event[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("list_open_files") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get all events for a specific file.
+ * 
+ * This command filters events based on permissions:
+ * - Block events: Only returns events for blocks where user has core.read permission
+ * - Editor events: Always returned (file-level information, similar to Git collaborators)
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `editor_id` - Optional editor ID (defaults to active editor)
+ * 
+ * # Returns
+ * * `Ok(Vec<Event>)` - List of events the user has permission to view
+ * * `Err(message)` - Error description if retrieval fails
+ */
+async getAllEvents(fileId: string, editorId: string | null) : Promise<Result<Event[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_all_events', { fileId, editorId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get detailed information about a file.
-   *
-   * Returns metadata including file name, path, collaborators (editors),
-   * and timestamps. The file must be open to retrieve this information.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   *
-   * # Returns
-   * * `Ok(FileMetadata)` - File metadata
-   * * `Err(message)` - Error description if retrieval fails
-   */
-  async getFileInfo(fileId: string): Promise<Result<FileMetadata, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_all_events", { fileId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get detailed information about a file.
+ * 
+ * Returns metadata including file name, path, collaborators (editors),
+ * and timestamps. The file must be open to retrieve this information.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * 
+ * # Returns
+ * * `Ok(FileMetadata)` - File metadata
+ * * `Err(message)` - Error description if retrieval fails
+ */
+async getFileInfo(fileId: string) : Promise<Result<FileMetadata, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_file_info', { fileId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Rename a file on the filesystem.
-   *
-   * This updates the file path both in the filesystem and in the application state.
-   * The file must be open to be renamed.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `new_name` - New name for the file (without extension)
-   *
-   * # Returns
-   * * `Ok(())` - File renamed successfully
-   * * `Err(message)` - Error description if rename fails
-   */
-  async renameFile(
-    fileId: string,
-    newName: string
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_file_info", { fileId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Rename a file on the filesystem.
+ * 
+ * This updates the file path both in the filesystem and in the application state.
+ * The file must be open to be renamed.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `new_name` - New name for the file (without extension)
+ * 
+ * # Returns
+ * * `Ok(())` - File renamed successfully
+ * * `Err(message)` - Error description if rename fails
+ */
+async renameFile(fileId: string, newName: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('rename_file', { fileId, newName }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Duplicate (copy) an existing .elf file.
-   *
-   * This creates a copy of the file with a new name and opens it for editing.
-   * The new file will have " Copy" appended to the name, or " Copy N" if that name exists.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file to duplicate
-   *
-   * # Returns
-   * * `Ok(new_file_id)` - Unique identifier for the newly created duplicate file
-   * * `Err(message)` - Error description if duplication fails
-   */
-  async duplicateFile(fileId: string): Promise<Result<string, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("rename_file", { fileId, newName }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Duplicate (copy) an existing .elf file.
+ * 
+ * This creates a copy of the file with a new name and opens it for editing.
+ * The new file will have " Copy" appended to the name, or " Copy N" if that name exists.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file to duplicate
+ * 
+ * # Returns
+ * * `Ok(new_file_id)` - Unique identifier for the newly created duplicate file
+ * * `Err(message)` - Error description if duplication fails
+ */
+async duplicateFile(fileId: string) : Promise<Result<string, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('duplicate_file', { fileId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get the global system editor ID from config.
-   *
-   * This returns the persistent system editor ID that is stored in
-   * the user's home directory config file (`$USER_HOME/.elf/config.json`).
-   *
-   * # Returns
-   * * `Ok(String)` - The system editor ID (UUID)
-   * * `Err(message)` - Error if config cannot be read
-   */
-  async getSystemEditorIdFromConfig(): Promise<Result<string, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("duplicate_file", { fileId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get the global system editor ID from config.
+ * 
+ * This returns the persistent system editor ID that is stored in
+ * the user's home directory config file (`$USER_HOME/.elf/config.json`).
+ * 
+ * # Returns
+ * * `Ok(String)` - The system editor ID (UUID)
+ * * `Err(message)` - Error if config cannot be read
+ */
+async getSystemEditorIdFromConfig() : Promise<Result<string, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_system_editor_id_from_config'),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get the full state snapshot (block + grants) at a specific event.
-   */
-  async getStateAtEvent(
-    fileId: string,
-    blockId: string,
-    eventId: string
-  ): Promise<Result<StateSnapshot, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_system_editor_id_from_config") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get the full state snapshot (block + grants) at a specific event.
+ */
+async getStateAtEvent(fileId: string, blockId: string, eventId: string) : Promise<Result<StateSnapshot, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_state_at_event', {
-          fileId,
-          blockId,
-          eventId,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Execute a command on a block in the specified file.
-   *
-   * This is the primary way to modify blocks. Commands are processed by the engine actor,
-   * which handles authorization, execution, and persistence.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file containing the block
-   * * `cmd` - Command to execute (create, delete, link, write, etc.)
-   *
-   * # Returns
-   * * `Ok(events)` - Events generated by the command execution
-   * * `Err(message)` - Error description if execution fails
-   */
-  async executeCommand(
-    fileId: string,
-    cmd: Command
-  ): Promise<Result<Event[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_state_at_event", { fileId, blockId, eventId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Execute a command on a block in the specified file.
+ * 
+ * This is the primary way to modify blocks. Commands are processed by the engine actor,
+ * which handles authorization, execution, and persistence.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file containing the block
+ * * `cmd` - Command to execute (create, delete, link, write, etc.)
+ * 
+ * # Returns
+ * * `Ok(events)` - Events generated by the command execution
+ * * `Err(message)` - Error description if execution fails
+ */
+async executeCommand(fileId: string, cmd: Command) : Promise<Result<Event[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('execute_command', { fileId, cmd }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get a specific block by ID from a file.
-   *
-   * This command checks read permission before returning the block content.
-   * The permission check uses the capability system (CBAC):
-   * - markdown blocks require `markdown.read` permission
-   * - code blocks require `code.read` permission
-   * - directory blocks require `directory.read` permission
-   *
-   * Block owners always have read permission.
-   * Other editors need explicit grants in the grants table.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file containing the block
-   * * `block_id` - Unique identifier of the block to retrieve
-   * * `editor_id` - Optional editor ID (defaults to active editor)
-   *
-   * # Returns
-   * * `Ok(block)` - The requested block (if authorized)
-   * * `Err(message)` - Error if file not open, block not found, or no read permission
-   */
-  async getBlock(
-    fileId: string,
-    blockId: string,
-    editorId: string | null
-  ): Promise<Result<Block, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("execute_command", { fileId, cmd }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get a specific block by ID from a file.
+ * 
+ * This command checks read permission before returning the block content.
+ * The permission check uses the capability system (CBAC):
+ * - markdown blocks require `markdown.read` permission
+ * - code blocks require `code.read` permission
+ * - directory blocks require `directory.read` permission
+ * 
+ * Block owners always have read permission.
+ * Other editors need explicit grants in the grants table.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file containing the block
+ * * `block_id` - Unique identifier of the block to retrieve
+ * * `editor_id` - Optional editor ID (defaults to active editor)
+ * 
+ * # Returns
+ * * `Ok(block)` - The requested block (if authorized)
+ * * `Err(message)` - Error if file not open, block not found, or no read permission
+ */
+async getBlock(fileId: string, blockId: string, editorId: string | null) : Promise<Result<Block, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_block', { fileId, blockId, editorId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get all blocks from a file.
-   *
-   * This command filters blocks based on permissions:
-   * - Only returns blocks where the user is owner OR has core.read OR has any other permission
-   * - For directory blocks with directory.read permission, returns full contents
-   * - For directory blocks without directory.read but with other permissions, returns empty entries
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `editor_id` - Optional editor ID (defaults to active editor)
-   *
-   * # Returns
-   * * `Ok(blocks)` - Vector of blocks the user has permission to view
-   * * `Err(message)` - Error if file is not open
-   */
-  async getAllBlocks(
-    fileId: string,
-    editorId: string | null
-  ): Promise<Result<Block[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_block", { fileId, blockId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get all blocks from a file.
+ * 
+ * This command filters blocks based on permissions:
+ * - Only returns blocks where the user is owner OR has core.read OR has any other permission
+ * - For directory blocks with directory.read permission, returns full contents
+ * - For directory blocks without directory.read but with other permissions, returns empty entries
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `editor_id` - Optional editor ID (defaults to active editor)
+ * 
+ * # Returns
+ * * `Ok(blocks)` - Vector of blocks the user has permission to view
+ * * `Err(message)` - Error if file is not open
+ */
+async getAllBlocks(fileId: string, editorId: string | null) : Promise<Result<Block[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_all_blocks', { fileId, editorId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Update block metadata.
-   *
-   * This generates a Command with core.update_metadata capability and processes it through
-   * the engine actor. The metadata is merged with existing metadata and updated via event replay.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file containing the block
-   * * `block_id` - Unique identifier of the block to update
-   * * `metadata` - Metadata fields to update (will be merged with existing metadata)
-   *
-   * # Returns
-   * * `Ok(())` - Metadata updated successfully
-   * * `Err(message)` - Error description if update fails
-   */
-  async updateBlockMetadata(
-    fileId: string,
-    blockId: string,
-    metadata: JsonValue
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_all_blocks", { fileId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Update block metadata.
+ * 
+ * This generates a Command with core.update_metadata capability and processes it through
+ * the engine actor. The metadata is merged with existing metadata and updated via event replay.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file containing the block
+ * * `block_id` - Unique identifier of the block to update
+ * * `metadata` - Metadata fields to update (will be merged with existing metadata)
+ * 
+ * # Returns
+ * * `Ok(())` - Metadata updated successfully
+ * * `Err(message)` - Error description if update fails
+ */
+async updateBlockMetadata(fileId: string, blockId: string, metadata: JsonValue) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('update_block_metadata', {
-          fileId,
-          blockId,
-          metadata,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Rename a block.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `block_id` - Unique identifier of the block
-   * * `name` - New name for the block
-   */
-  async renameBlock(
-    fileId: string,
-    blockId: string,
-    name: string
-  ): Promise<Result<Event[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("update_block_metadata", { fileId, blockId, metadata }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Rename a block.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `block_id` - Unique identifier of the block
+ * * `name` - New name for the block
+ */
+async renameBlock(fileId: string, blockId: string, name: string) : Promise<Result<Event[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('rename_block', { fileId, blockId, name }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Change the type of a block.
-   *
-   * This command provides smart type changing with automatic inference from file extensions.
-   * It wraps the core.change_type capability with additional convenience features.
-   *
-   * # Type Inference Logic
-   * 1. If `block_type` is provided, use it directly
-   * 2. If `file_extension` is provided, use `infer_block_type()` to determine type
-   * 3. If both are provided, `block_type` takes precedence
-   * 4. If neither is provided, returns an error
-   *
-   * # Use Cases
-   * - User explicitly selects new type via UI: pass `block_type`
-   * - After file rename with extension change: pass `file_extension` for auto-inference
-   * - Direct type conversion: pass `block_type` with exact type string
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `block_id` - Unique identifier of the block
-   * * `block_type` - Optional: directly specify the new block type
-   * * `file_extension` - Optional: file extension to infer type from (e.g., "md", "rs", "txt")
-   *
-   * # Returns
-   * * `Ok(events)` - Events generated by the type change
-   * * `Err(message)` - Error if inference fails or parameters are invalid
-   *
-   * # Examples
-   *
-   * Direct type specification:
-   * ```rust,no_run
-   * use tauri::State;
-   * use elfiee_lib::state::AppState;
-   * use elfiee_lib::commands::block::change_block_type;
-   *
-   * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
-   * change_block_type(
-   * "file_123".to_string(),
-   * "block_456".to_string(),
-   * Some("markdown".to_string()),
-   * None,
-   * state
-   * ).await?;
-   * # Ok(())
-   * # }
-   * ```
-   *
-   * Infer type from extension:
-   * ```rust,no_run
-   * use tauri::State;
-   * use elfiee_lib::state::AppState;
-   * use elfiee_lib::commands::block::change_block_type;
-   *
-   * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
-   * change_block_type(
-   * "file_123".to_string(),
-   * "block_456".to_string(),
-   * None,
-   * Some("md".to_string()),
-   * state
-   * ).await?;
-   * # Ok(())
-   * # }
-   * ```
-   */
-  async changeBlockType(
-    fileId: string,
-    blockId: string,
-    blockType: string | null,
-    fileExtension: string | null
-  ): Promise<Result<Event[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("rename_block", { fileId, blockId, name }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Change the type of a block.
+ * 
+ * This command provides smart type changing with automatic inference from file extensions.
+ * It wraps the core.change_type capability with additional convenience features.
+ * 
+ * # Type Inference Logic
+ * 1. If `block_type` is provided, use it directly
+ * 2. If `file_extension` is provided, use `infer_block_type()` to determine type
+ * 3. If both are provided, `block_type` takes precedence
+ * 4. If neither is provided, returns an error
+ * 
+ * # Use Cases
+ * - User explicitly selects new type via UI: pass `block_type`
+ * - After file rename with extension change: pass `file_extension` for auto-inference
+ * - Direct type conversion: pass `block_type` with exact type string
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `block_id` - Unique identifier of the block
+ * * `block_type` - Optional: directly specify the new block type
+ * * `file_extension` - Optional: file extension to infer type from (e.g., "md", "rs", "txt")
+ * 
+ * # Returns
+ * * `Ok(events)` - Events generated by the type change
+ * * `Err(message)` - Error if inference fails or parameters are invalid
+ * 
+ * # Examples
+ * 
+ * Direct type specification:
+ * ```rust,no_run
+ * use tauri::State;
+ * use elfiee_lib::state::AppState;
+ * use elfiee_lib::commands::block::change_block_type;
+ * 
+ * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
+ * change_block_type(
+ * "file_123".to_string(),
+ * "block_456".to_string(),
+ * Some("markdown".to_string()),
+ * None,
+ * state
+ * ).await?;
+ * # Ok(())
+ * # }
+ * ```
+ * 
+ * Infer type from extension:
+ * ```rust,no_run
+ * use tauri::State;
+ * use elfiee_lib::state::AppState;
+ * use elfiee_lib::commands::block::change_block_type;
+ * 
+ * # async fn wrapper(state: State<'_, AppState>) -> Result<(), String> {
+ * change_block_type(
+ * "file_123".to_string(),
+ * "block_456".to_string(),
+ * None,
+ * Some("md".to_string()),
+ * state
+ * ).await?;
+ * # Ok(())
+ * # }
+ * ```
+ */
+async changeBlockType(fileId: string, blockId: string, blockType: string | null, fileExtension: string | null) : Promise<Result<Event[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('change_block_type', {
-          fileId,
-          blockId,
-          blockType,
-          fileExtension,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Check if current editor has permission for a capability on a block.
-   */
-  async checkPermission(
-    fileId: string,
-    blockId: string,
-    capability: string,
-    editorId: string | null
-  ): Promise<Result<boolean, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("change_block_type", { fileId, blockId, blockType, fileExtension }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Check if current editor has permission for a capability on a block.
+ */
+async checkPermission(fileId: string, blockId: string, capability: string, editorId: string | null) : Promise<Result<boolean, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('check_permission', {
-          fileId,
-          blockId,
-          capability,
-          editorId,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Create a new editor for the specified file.
-   *
-   * This generates a Command with editor.create capability and processes it through
-   * the engine actor. The new editor is added to the file's state via event replay.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `name` - Display name for the new editor
-   * * `editor_type` - Optional editor type (Human or Bot)
-   * * `block_id` - Optional block ID. If provided, only the block owner can create editors.
-   *
-   * # Returns
-   * * `Ok(Editor)` - The newly created editor
-   * * `Err(message)` - Error description if creation fails
-   */
-  async createEditor(
-    fileId: string,
-    name: string,
-    editorType: string | null,
-    blockId: string | null
-  ): Promise<Result<Editor, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("check_permission", { fileId, blockId, capability, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Create a new editor for the specified file.
+ * 
+ * This generates a Command with editor.create capability and processes it through
+ * the engine actor. The new editor is added to the file's state via event replay.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `name` - Display name for the new editor
+ * * `editor_type` - Optional editor type (Human or Bot)
+ * * `block_id` - Optional block ID. If provided, only the block owner can create editors.
+ * 
+ * # Returns
+ * * `Ok(Editor)` - The newly created editor
+ * * `Err(message)` - Error description if creation fails
+ */
+async createEditor(fileId: string, name: string, editorType: string | null, blockId: string | null) : Promise<Result<Editor, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('create_editor', {
-          fileId,
-          name,
-          editorType,
-          blockId,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Delete an editor identity from the specified file.
-   *
-   * This generates a Command with editor.delete capability and processes it through
-   * the engine actor. The editor and associated grants are removed from the state.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `editor_id` - Unique identifier of the editor to delete
-   * * `block_id` - Optional block ID. If provided, only the block owner can delete editors.
-   *
-   * # Returns
-   * * `Ok(())` - Success
-   * * `Err(message)` - Error description if deletion fails
-   */
-  async deleteEditor(
-    fileId: string,
-    editorId: string,
-    blockId: string | null
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("create_editor", { fileId, name, editorType, blockId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Delete an editor identity from the specified file.
+ * 
+ * This generates a Command with editor.delete capability and processes it through
+ * the engine actor. The editor and associated grants are removed from the state.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `editor_id` - Unique identifier of the editor to delete
+ * * `block_id` - Optional block ID. If provided, only the block owner can delete editors.
+ * 
+ * # Returns
+ * * `Ok(())` - Success
+ * * `Err(message)` - Error description if deletion fails
+ */
+async deleteEditor(fileId: string, editorId: string, blockId: string | null) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('delete_editor', {
-          fileId,
-          editorId,
-          blockId,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * List all editors for the specified file.
-   *
-   * Reads the editors from the StateProjector which is built from event replay.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   *
-   * # Returns
-   * * `Ok(Vec<Editor>)` - List of all editors
-   * * `Err(message)` - Error if file is not open
-   */
-  async listEditors(fileId: string): Promise<Result<Editor[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("delete_editor", { fileId, editorId, blockId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * List all editors for the specified file.
+ * 
+ * Reads the editors from the StateProjector which is built from event replay.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * 
+ * # Returns
+ * * `Ok(Vec<Editor>)` - List of all editors
+ * * `Err(message)` - Error if file is not open
+ */
+async listEditors(fileId: string) : Promise<Result<Editor[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('list_editors', { fileId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get a specific editor by ID.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `editor_id` - Unique identifier of the editor
-   *
-   * # Returns
-   * * `Ok(Editor)` - The requested editor
-   * * `Err(message)` - Error if file not open or editor not found
-   */
-  async getEditor(
-    fileId: string,
-    editorId: string
-  ): Promise<Result<Editor, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("list_editors", { fileId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get a specific editor by ID.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `editor_id` - Unique identifier of the editor
+ * 
+ * # Returns
+ * * `Ok(Editor)` - The requested editor
+ * * `Err(message)` - Error if file not open or editor not found
+ */
+async getEditor(fileId: string, editorId: string) : Promise<Result<Editor, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_editor', { fileId, editorId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Set the active editor for the specified file.
-   *
-   * This is a UI state operation and is not persisted to the .elf file.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `editor_id` - Unique identifier of the editor to set as active
-   *
-   * # Returns
-   * * `Ok(())` - Success
-   * * `Err(message)` - Error if file or editor not found
-   */
-  async setActiveEditor(
-    fileId: string,
-    editorId: string
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_editor", { fileId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Set the active editor for the specified file.
+ * 
+ * This is a UI state operation and is not persisted to the .elf file.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `editor_id` - Unique identifier of the editor to set as active
+ * 
+ * # Returns
+ * * `Ok(())` - Success
+ * * `Err(message)` - Error if file or editor not found
+ */
+async setActiveEditor(fileId: string, editorId: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('set_active_editor', { fileId, editorId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get the currently active editor for the specified file.
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   *
-   * # Returns
-   * * `Ok(Option<String>)` - Editor ID if one is active, None otherwise
-   * * `Err(message)` - Error if file is not open
-   */
-  async getActiveEditor(
-    fileId: string
-  ): Promise<Result<string | null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("set_active_editor", { fileId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get the currently active editor for the specified file.
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * 
+ * # Returns
+ * * `Ok(Option<String>)` - Editor ID if one is active, None otherwise
+ * * `Err(message)` - Error if file is not open
+ */
+async getActiveEditor(fileId: string) : Promise<Result<string | null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_active_editor', { fileId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * List all grants for the specified file.
-   *
-   * This command filters grants based on permissions:
-   * - Only returns grants for blocks where the user has core.read permission
-   * - Wildcard grants (*) are always included as they are file-level
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `editor_id` - Optional editor ID (defaults to active editor)
-   *
-   * # Returns
-   * * `Ok(Vec<Grant>)` - List of grants the user has permission to view
-   * * `Err(message)` - Error if file is not open
-   */
-  async listGrants(
-    fileId: string,
-    editorId: string | null
-  ): Promise<Result<Grant[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_active_editor", { fileId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * List all grants for the specified file.
+ * 
+ * This command filters grants based on permissions:
+ * - Only returns grants for blocks where the user has core.read permission
+ * - Wildcard grants (*) are always included as they are file-level
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `editor_id` - Optional editor ID (defaults to active editor)
+ * 
+ * # Returns
+ * * `Ok(Vec<Grant>)` - List of grants the user has permission to view
+ * * `Err(message)` - Error if file is not open
+ */
+async listGrants(fileId: string, editorId: string | null) : Promise<Result<Grant[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('list_grants', { fileId, editorId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Get grants for a specific block.
-   *
-   * Returns all grants that apply to this block (including wildcard grants).
-   *
-   * # Arguments
-   * * `file_id` - Unique identifier of the file
-   * * `block_id` - Unique identifier of the block
-   *
-   * # Returns
-   * * `Ok(Vec<Grant>)` - List of grants for the block
-   * * `Err(message)` - Error if file is not open
-   */
-  async getBlockGrants(
-    fileId: string,
-    blockId: string
-  ): Promise<Result<Grant[], string>> {
+    return { status: "ok", data: await TAURI_INVOKE("list_grants", { fileId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Get grants for a specific block.
+ * 
+ * Returns all grants that apply to this block (including wildcard grants).
+ * 
+ * # Arguments
+ * * `file_id` - Unique identifier of the file
+ * * `block_id` - Unique identifier of the block
+ * 
+ * # Returns
+ * * `Ok(Vec<Grant>)` - List of grants for the block
+ * * `Err(message)` - Error if file is not open
+ */
+async getBlockGrants(fileId: string, blockId: string) : Promise<Result<Grant[], string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('get_block_grants', { fileId, blockId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Materialize blocks to the external file system (Checkout).
-   */
-  async checkoutWorkspace(
-    fileId: string,
-    blockId: string,
-    payload: DirectoryExportPayload
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("get_block_grants", { fileId, blockId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Materialize blocks to the external file system (Checkout).
+ * 
+ * This command implements the bottom-layer I/O ability:
+ * 1. Calls the `directory.export` capability for authorization and auditing.
+ * 2. If authorized, performs the 'checkout' by writing block contents to the target path.
+ */
+async checkoutWorkspace(fileId: string, blockId: string, payload: DirectoryExportPayload) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('checkout_workspace', {
-          fileId,
-          blockId,
-          payload,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Execute a task commit (Tauri command wrapper).
-   */
-  async commitTask(
-    fileId: string,
-    taskBlockId: string,
-    editorId: string | null
-  ): Promise<Result<TaskCommitResult, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("checkout_workspace", { fileId, blockId, payload }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Execute a task commit: validate → auto-discover repo → export snapshots → git commit.
+ * 
+ * This command follows the Split Pattern:
+ * 1. Calls task.commit capability handler (authorization + audit event)
+ * 2. Auto-discovers linked repo from downstream blocks
+ * 3. Verifies discovered path has .git
+ * 4. Copies downstream block snapshots to repo path
+ * 5. Executes git branch + add + commit flow
+ * 
+ * # Arguments
+ * * `file_id` - Elf file containing the task block
+ * * `task_block_id` - The task block to commit
+ * * `editor_id` - Optional editor ID (defaults to active editor)
+ */
+async commitTask(fileId: string, taskBlockId: string, editorId: string | null) : Promise<Result<TaskCommitResult, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('commit_task', {
-          fileId,
-          taskBlockId,
-          editorId,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Inject git hooks into a linked repository (commit protect ON).
-   *
-   * Hooks are stored in the .elf temp dir, so they disappear on crash/close.
-   * Sets `core.hooksPath` to block direct commits and require task.commit workflow.
-   * Hook content is read from the .elf/ block (event sourced).
-   */
-  async injectHooksForRepo(
-    fileId: string,
-    repoPath: string
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("commit_task", { fileId, taskBlockId, editorId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Inject git hooks into a linked repository (commit protect ON).
+ * 
+ * Hooks are stored in the .elf temp dir, so they disappear on crash/close.
+ * Sets `core.hooksPath` to block direct commits and require task.commit workflow.
+ * 
+ * # Arguments
+ * * `file_id` - Elf file ID (used to locate temp dir)
+ * * `repo_path` - External project git repo root
+ */
+async injectHooksForRepo(fileId: string, repoPath: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('inject_hooks_for_repo', { fileId, repoPath }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Remove git hooks from a linked repository (commit protect OFF).
-   *
-   * Restores original `core.hooksPath` and cleans up Elfiee hook files.
-   */
-  async removeHooksForRepo(
-    fileId: string,
-    repoPath: string
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("inject_hooks_for_repo", { fileId, repoPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Remove git hooks from a linked repository (commit protect OFF).
+ * 
+ * Restores original `core.hooksPath` and cleans up Elfiee hook files.
+ */
+async removeHooksForRepo(fileId: string, repoPath: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('remove_hooks_for_repo', { fileId, repoPath }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Check if git hooks are currently injected for a repo.
-   */
-  async isHooksActive(
-    fileId: string,
-    repoPath: string
-  ): Promise<Result<boolean, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("remove_hooks_for_repo", { fileId, repoPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Check if git hooks are currently injected for a repo.
+ */
+async isHooksActive(fileId: string, repoPath: string) : Promise<Result<boolean, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('is_hooks_active', { fileId, repoPath }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Initialize and create a new PTY session.
-   *
-   * This command:
-   * 1. Creates a PTY using pure functions from utils/pty.rs
-   * 2. Spawns a shell process
-   * 3. Starts a reader thread to forward PTY output to the frontend
-   * 4. Stores the session in TerminalState
-   *
-   * Note: The terminal.init capability should be called separately via
-   * execute_command to record the session_started event.
-   *
-   * # Arguments
-   * * `app` - Tauri app handle for emitting events
-   * * `state` - Terminal state containing active sessions
-   * * `block_id` - The terminal block ID
-   * * `cols` - Number of columns
-   * * `rows` - Number of rows
-   * * `cwd` - Optional working directory
-   *
-   * # Returns
-   * * `Ok(())` - Session created successfully
-   * * `Err(String)` - Error if creation fails
-   */
-  async initPtySession(
-    blockId: string,
-    cols: number,
-    rows: number,
-    cwd: string | null
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("is_hooks_active", { fileId, repoPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Initialize and create a new PTY session.
+ * 
+ * This command:
+ * 1. Creates a PTY using pure functions from utils/pty.rs
+ * 2. Spawns a shell process
+ * 3. Starts a reader thread to forward PTY output to the frontend
+ * 4. Stores the session in TerminalState
+ * 
+ * Note: The terminal.init capability should be called separately via
+ * execute_command to record the session_started event.
+ * 
+ * # Arguments
+ * * `app` - Tauri app handle for emitting events
+ * * `state` - Terminal state containing active sessions
+ * * `block_id` - The terminal block ID
+ * * `cols` - Number of columns
+ * * `rows` - Number of rows
+ * * `cwd` - Optional working directory
+ * 
+ * # Returns
+ * * `Ok(())` - Session created successfully
+ * * `Err(String)` - Error if creation fails
+ */
+async initPtySession(blockId: string, cols: number, rows: number, cwd: string | null) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('init_pty_session', {
-          blockId,
-          cols,
-          rows,
-          cwd,
-        }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Write data to the PTY.
-   *
-   * This command forwards user input from the frontend terminal (xterm.js)
-   * to the backend PTY process.
-   *
-   * **Note**: This is a high-frequency operation (called on every keystroke).
-   * No capability check is performed for performance reasons.
-   * Authorization was already checked during session initialization.
-   *
-   * # Arguments
-   * * `state` - Terminal state containing active sessions
-   * * `block_id` - The terminal block ID
-   * * `data` - The data to write (user input)
-   *
-   * # Returns
-   * * `Ok(())` - Data written successfully
-   * * `Err(String)` - Error if session not found or write fails
-   */
-  async writeToPty(
-    blockId: string,
-    data: string
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("init_pty_session", { blockId, cols, rows, cwd }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Write data to the PTY.
+ * 
+ * This command forwards user input from the frontend terminal (xterm.js)
+ * to the backend PTY process.
+ * 
+ * **Note**: This is a high-frequency operation (called on every keystroke).
+ * No capability check is performed for performance reasons.
+ * Authorization was already checked during session initialization.
+ * 
+ * # Arguments
+ * * `state` - Terminal state containing active sessions
+ * * `block_id` - The terminal block ID
+ * * `data` - The data to write (user input)
+ * 
+ * # Returns
+ * * `Ok(())` - Data written successfully
+ * * `Err(String)` - Error if session not found or write fails
+ */
+async writeToPty(blockId: string, data: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('write_to_pty', { blockId, data }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Resize the PTY.
-   *
-   * This command updates the PTY window dimensions when the frontend
-   * terminal viewport changes size.
-   *
-   * **Note**: This is a high-frequency operation (called on window resize).
-   * No capability check is performed for performance reasons.
-   * Authorization was already checked during session initialization.
-   *
-   * # Arguments
-   * * `state` - Terminal state containing active sessions
-   * * `block_id` - The terminal block ID
-   * * `cols` - New number of columns
-   * * `rows` - New number of rows
-   *
-   * # Returns
-   * * `Ok(())` - PTY resized successfully
-   * * `Err(String)` - Error if session not found or resize fails
-   */
-  async resizePty(
-    blockId: string,
-    cols: number,
-    rows: number
-  ): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("write_to_pty", { blockId, data }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Resize the PTY.
+ * 
+ * This command updates the PTY window dimensions when the frontend
+ * terminal viewport changes size.
+ * 
+ * **Note**: This is a high-frequency operation (called on window resize).
+ * No capability check is performed for performance reasons.
+ * Authorization was already checked during session initialization.
+ * 
+ * # Arguments
+ * * `state` - Terminal state containing active sessions
+ * * `block_id` - The terminal block ID
+ * * `cols` - New number of columns
+ * * `rows` - New number of rows
+ * 
+ * # Returns
+ * * `Ok(())` - PTY resized successfully
+ * * `Err(String)` - Error if session not found or resize fails
+ */
+async resizePty(blockId: string, cols: number, rows: number) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('resize_pty', { blockId, cols, rows }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Close a PTY session.
-   *
-   * This command removes the session from state and drops the PTY resources.
-   * When the session is dropped, the reader thread receives EOF and exits naturally.
-   *
-   * Note: The terminal.close capability should be called separately via
-   * execute_command to record the session_closed event.
-   *
-   * # Arguments
-   * * `state` - Terminal state containing active sessions
-   * * `block_id` - The terminal block ID
-   *
-   * # Returns
-   * * `Ok(())` - Session closed successfully (or was already closed)
-   * * `Err(String)` - Error if operation fails
-   */
-  async closePtySession(blockId: string): Promise<Result<null, string>> {
+    return { status: "ok", data: await TAURI_INVOKE("resize_pty", { blockId, cols, rows }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Close a PTY session.
+ * 
+ * This command removes the session from state and drops the PTY resources.
+ * When the session is dropped, the reader thread receives EOF and exits naturally.
+ * 
+ * Note: The terminal.close capability should be called separately via
+ * execute_command to record the session_closed event.
+ * 
+ * # Arguments
+ * * `state` - Terminal state containing active sessions
+ * * `block_id` - The terminal block ID
+ * 
+ * # Returns
+ * * `Ok(())` - Session closed successfully (or was already closed)
+ * * `Err(String)` - Error if operation fails
+ */
+async closePtySession(blockId: string) : Promise<Result<null, string>> {
     try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('close_pty_session', { blockId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Create an Agent Block bound to a .claude/ directory and auto-enable it.
-   */
-  async agentCreate(
-    fileId: string,
-    payload: AgentCreatePayload
-  ): Promise<Result<AgentCreateResult, string>> {
-    try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('agent_create', { fileId, payload }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Enable an Agent Block: recreate symlink and inject MCP config.
-   */
-  async agentEnable(
-    fileId: string,
-    agentBlockId: string
-  ): Promise<Result<AgentEnableResult, string>> {
-    try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('agent_enable', { fileId, agentBlockId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
-  /**
-   * Disable an Agent Block: remove symlink and MCP config.
-   */
-  async agentDisable(
-    fileId: string,
-    agentBlockId: string
-  ): Promise<Result<AgentDisableResult, string>> {
-    try {
-      return {
-        status: 'ok',
-        data: await TAURI_INVOKE('agent_disable', { fileId, agentBlockId }),
-      }
-    } catch (e) {
-      if (e instanceof Error) throw e
-      else return { status: 'error', error: e as any }
-    }
-  },
+    return { status: "ok", data: await TAURI_INVOKE("close_pty_session", { blockId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+}
 }
 
 /** user-defined events **/
 
-export const events = __makeEvents__<{
-  ptyOutputEvent: PtyOutputEvent
-  stateChangedEvent: StateChangedEvent
-}>({
-  ptyOutputEvent: 'pty-output-event',
-  stateChangedEvent: 'state-changed-event',
-})
+
 
 /** user-defined constants **/
+
+
 
 /** user-defined types **/
 
 /**
- * Agent Block contents, storing per-AI-tool integration config.
- *
- * Stored in `Block.contents`.
- *
- * Key change from V1: binds to `config_dir` (absolute path) instead of Dir Block ID.
- * `editor_id` is now required (not optional).
- */
-export type AgentContents = {
-  /**
-   * Agent display name (default: "elfiee")
-   */
-  name: string
-  /**
-   * AI tool provider identifier.
-   *
-   * Examples: "claude_code", "cursor", "windsurf"
-   * Used to determine provider-specific behavior (symlink paths, MCP config format, etc.)
-   */
-  provider?: string
-  /**
-   * Absolute path to the AI tool's config directory this agent is bound to.
-   *
-   * Examples:
-   * - Claude Code: "/home/user/repo-a/.claude"
-   * - Cursor: "/home/user/repo-a/.cursor"
-   *
-   * Used to derive:
-   * - Symlink target: `{config_dir}/skills/elfiee-client/`
-   * - MCP config locations: `{config_dir.parent()}/.mcp.json` + `{config_dir}/mcp.json`
-   */
-  config_dir: string
-  /**
-   * Agent current status
-   */
-  status: AgentStatus
-  /**
-   * Bot editor_id associated with this agent (required).
-   * Used by per-agent MCP server to attribute operations to the correct identity.
-   */
-  editor_id: string
-}
-/**
- * Payload for agent.create capability
- */
-export type AgentCreatePayload = {
-  /**
-   * Agent display name (optional, default: "elfiee")
-   */
-  name?: string | null
-  /**
-   * AI tool provider identifier (optional, default: "claude_code")
-   */
-  provider?: string
-  /**
-   * Absolute path to the AI tool's config directory (required)
-   */
-  config_dir: string
-  /**
-   * Bot editor_id to associate with this agent.
-   * If not provided, the command layer auto-creates a bot editor.
-   */
-  editor_id?: string | null
-}
-/**
- * Result type for agent.create Tauri command
- */
-export type AgentCreateResult = {
-  /**
-   * Created Agent Block ID
-   */
-  agent_block_id: string
-  /**
-   * Agent status after creation
-   */
-  status: AgentStatus
-  /**
-   * Whether the user needs to restart Claude Code
-   */
-  needs_restart: boolean
-  /**
-   * Human-readable message
-   */
-  message: string
-}
-/**
- * Payload for agent.disable capability
- */
-export type AgentDisablePayload = {
-  /**
-   * Agent Block ID (required)
-   */
-  agent_block_id: string
-}
-/**
- * Result type for agent.disable Tauri command
- */
-export type AgentDisableResult = {
-  /**
-   * Agent Block ID
-   */
-  agent_block_id: string
-  /**
-   * Agent status after disable
-   */
-  status: AgentStatus
-  /**
-   * Human-readable message
-   */
-  message: string
-  /**
-   * Warnings for partial failures
-   */
-  warnings: string[]
-}
-/**
- * Payload for agent.enable capability
- */
-export type AgentEnablePayload = {
-  /**
-   * Agent Block ID (required)
-   */
-  agent_block_id: string
-}
-/**
- * Result type for agent.enable Tauri command
- */
-export type AgentEnableResult = {
-  /**
-   * Agent Block ID
-   */
-  agent_block_id: string
-  /**
-   * Agent status after enable
-   */
-  status: AgentStatus
-  /**
-   * Whether the user needs to restart Claude Code
-   */
-  needs_restart: boolean
-  /**
-   * Human-readable message
-   */
-  message: string
-  /**
-   * Warnings for partial failures (e.g. symlink OK but MCP config failed)
-   */
-  warnings: string[]
-}
-/**
- * Agent enable/disable status
- */
-export type AgentStatus =
-  /**
-   * Enabled: symlink exists, MCP config injected, MCP server running
-   */
-  | 'enabled'
-  /**
-   * Disabled: symlink cleaned, MCP config removed, MCP server stopped
-   */
-  | 'disabled'
-/**
  * Block 是 Elfiee 的基本内容单元。
- *
+ * 
  * `children` 字段存储逻辑因果关系图（Logical Causal Graph），
  * key 仅允许 `RELATION_IMPLEMENT`（即 `"implement"`），
  * value 为下游 block_id 列表。
  */
-export type Block = {
-  block_id: string
-  name: string
-  block_type: string
-  contents: JsonValue
-  children: Partial<{ [key in string]: string[] }>
-  owner: string
-  /**
-   * Block metadata with timestamps and custom fields
-   */
-  metadata: BlockMetadata
-}
+export type Block = { block_id: string; name: string; block_type: string; contents: JsonValue; children: Partial<{ [key in string]: string[] }>; owner: string; 
+/**
+ * Block metadata with timestamps and custom fields
+ */
+metadata: BlockMetadata }
 /**
  * Block metadata structure (recommended format)
- *
+ * 
  * Stored in Block.metadata field (JSON format).
  * This structure defines the recommended metadata format, but is not enforced.
- *
+ * 
  * # Fields
  * * `description` - Detailed description of the block
  * * `created_at` - Creation timestamp (ISO 8601 UTC format, e.g., "2025-12-17T02:30:00Z")
  * * `updated_at` - Last update timestamp (ISO 8601 UTC format)
  * * `custom` - Custom extension fields (merged into root object via #[serde(flatten)])
  */
-export type BlockMetadata =
-  /**
-   * Custom extension fields
-   */
-  Partial<{
-    [key in string]:
-      | null
-      | boolean
-      | number
-      | string
-      | JsonValue[]
-      | Partial<{ [key in string]: JsonValue }>
-  }> & {
-    /**
-     * Block description
-     */
-    description?: string | null
-    /**
-     * Creation timestamp (ISO 8601 UTC)
-     */
-    created_at?: string | null
-    /**
-     * Last update timestamp (ISO 8601 UTC)
-     */
-    updated_at?: string | null
-  }
+export type BlockMetadata = 
+/**
+ * Custom extension fields
+ */
+(Partial<{ [key in string]: null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }> }>) & { 
+/**
+ * Block description
+ */
+description?: string | null; 
+/**
+ * Creation timestamp (ISO 8601 UTC)
+ */
+created_at?: string | null; 
+/**
+ * Last update timestamp (ISO 8601 UTC)
+ */
+updated_at?: string | null }
 /**
  * Payload for CodeRead
  */
@@ -1267,65 +832,45 @@ export type CodeReadPayload = Record<string, never>
 /**
  * Payload for CodeWrite
  */
-export type CodeWritePayload = {
-  /**
-   * The source code text content to write
-   */
-  content: string
-}
-export type Command = {
-  cmd_id: string
-  editor_id: string
-  cap_id: string
-  block_id: string
-  payload: JsonValue
-  /**
-   * UTC timestamp when the command was created (timezone-aware)
-   */
-  timestamp: string
-}
+export type CodeWritePayload = { 
+/**
+ * The source code text content to write
+ */
+content: string }
+export type Command = { cmd_id: string; editor_id: string; cap_id: string; block_id: string; payload: JsonValue; 
+/**
+ * UTC timestamp when the command was created (timezone-aware)
+ */
+timestamp: string }
 /**
  * Payload for core.create capability
- *
+ * 
  * This payload is used to create a new block with a name and type.
  */
-export type CreateBlockPayload = {
-  /**
-   * The display name for the new block
-   */
-  name: string
-  /**
-   * The block type (e.g., "markdown", "code", "diagram")
-   */
-  block_type: string
-  /**
-   * The source category of the block ("outline" or "linked")
-   */
-  source?: string
-  /**
-   * Optional metadata (description, custom fields, etc.)
-   *
-   * If provided, will be merged with auto-generated timestamps.
-   * Example: { "description": "项目需求文档" }
-   */
-  metadata?: JsonValue | null
-}
+export type CreateBlockPayload = { 
+/**
+ * The display name for the new block
+ */
+name: string; 
+/**
+ * The block type (e.g., "markdown", "code", "diagram")
+ */
+block_type: string; 
+/**
+ * The source category of the block ("outline" or "linked")
+ */
+source?: string; 
+/**
+ * Optional metadata (description, custom fields, etc.)
+ * 
+ * If provided, will be merged with auto-generated timestamps.
+ * Example: { "description": "项目需求文档" }
+ */
+metadata?: JsonValue | null }
 /**
  * Payload for DirectoryCreate
  */
-export type DirectoryCreatePayload = {
-  path: string
-  type: string
-  source: string
-  content?: string | null
-  block_type?: string | null
-  /**
-   * Optional: Link an existing block instead of creating a new one.
-   * When provided (and entry_type is "file"), skips core.create and
-   * registers the existing block_id in the directory index.
-   */
-  existing_block_id?: string | null
-}
+export type DirectoryCreatePayload = { path: string; type: string; source: string; content?: string | null; block_type?: string | null }
 /**
  * Payload for DirectoryDelete
  */
@@ -1333,245 +878,178 @@ export type DirectoryDeletePayload = { path: string }
 /**
  * Payload for DirectoryExport
  */
-export type DirectoryExportPayload = {
-  target_path: string
-  source_path?: string | null
-}
+export type DirectoryExportPayload = { target_path: string; source_path?: string | null }
 /**
  * Payload for DirectoryImport
  */
-export type DirectoryImportPayload = {
-  source_path: string
-  target_path?: string | null
-}
+export type DirectoryImportPayload = { source_path: string; target_path?: string | null }
 /**
  * Payload for DirectoryRename
  */
 export type DirectoryRenamePayload = { old_path: string; new_path: string }
 /**
  * Payload for DirectoryRenameWithTypeChange
- *
+ * 
  * Atomically renames a file entry and changes its block type in a single transaction.
  * This ensures consistency when file extension changes require block type updates.
  */
-export type DirectoryRenameWithTypeChangePayload = {
-  old_path: string
-  new_path: string
-  /**
-   * Optional: Directly specify the new block type (e.g., "markdown", "code")
-   */
-  block_type?: string | null
-  /**
-   * Optional: Infer block type from file extension (e.g., "md", "rs", "txt")
-   */
-  file_extension?: string | null
-}
+export type DirectoryRenameWithTypeChangePayload = { old_path: string; new_path: string; 
+/**
+ * Optional: Directly specify the new block type (e.g., "markdown", "code")
+ */
+block_type?: string | null; 
+/**
+ * Optional: Infer block type from file extension (e.g., "md", "rs", "txt")
+ */
+file_extension?: string | null }
 /**
  * Payload for directory.write capability.
- *
+ * 
  * Used to directly update the entries map of a directory block.
  */
-export type DirectoryWritePayload = {
-  /**
-   * The full entries map to be saved
-   */
-  entries: JsonValue
-  /**
-   * The source category of this directory block ("outline" or "linked")
-   */
-  source?: string | null
-}
-export type Editor = {
-  editor_id: string
-  name: string
-  editor_type?: EditorType
-}
+export type DirectoryWritePayload = { 
+/**
+ * The full entries map to be saved
+ */
+entries: JsonValue; 
+/**
+ * The source category of this directory block ("outline" or "linked")
+ */
+source?: string | null }
+export type Editor = { editor_id: string; name: string; editor_type?: EditorType }
 /**
  * Payload for editor.create capability
- *
+ * 
  * This payload is used to create a new editor identity in the file.
  */
-export type EditorCreatePayload = {
-  /**
-   * The display name for the new editor
-   */
-  name: string
-  /**
-   * The type of editor (Human or Bot), defaults to Human if not specified
-   */
-  editor_type?: string | null
-  /**
-   * Optional explicitly provided editor ID (e.g. system editor ID)
-   */
-  editor_id?: string | null
-}
+export type EditorCreatePayload = { 
+/**
+ * The display name for the new editor
+ */
+name: string; 
+/**
+ * The type of editor (Human or Bot), defaults to Human if not specified
+ */
+editor_type?: string | null; 
+/**
+ * Optional explicitly provided editor ID (e.g. system editor ID)
+ */
+editor_id?: string | null }
 /**
  * Payload for editor.delete capability
- *
+ * 
  * This payload is used to delete an editor identity from the file.
  */
-export type EditorDeletePayload = {
-  /**
-   * The editor ID to delete
-   */
-  editor_id: string
-}
-export type EditorType = 'Human' | 'Bot'
-export type Event = {
-  event_id: string
-  entity: string
-  attribute: string
-  value: JsonValue
-  timestamp: Partial<{ [key in string]: number }>
-  created_at: string
-}
+export type EditorDeletePayload = { 
+/**
+ * The editor ID to delete
+ */
+editor_id: string }
+export type EditorType = "Human" | "Bot"
+export type Event = { event_id: string; entity: string; attribute: string; value: JsonValue; timestamp: Partial<{ [key in string]: number }>; created_at: string }
 /**
  * File metadata for frontend display.
- *
+ * 
  * This structure contains all information about a file that the UI needs to display,
  * including the file name, path, collaborators (editors), and timestamps.
  */
-export type FileMetadata = {
-  file_id: string
-  name: string
-  path: string
-  collaborators: string[]
-  created_at: string
-  updated_at: string
-}
+export type FileMetadata = { file_id: string; name: string; path: string; collaborators: string[]; created_at: string; updated_at: string }
 /**
  * Represents a capability grant in the CBAC system.
- *
+ * 
  * Grants define which editors have which capabilities on which blocks.
  * They are projected from grant/revoke events in the EventStore.
  */
-export type Grant = {
-  /**
-   * The editor who has been granted the capability
-   */
-  editor_id: string
-  /**
-   * The capability that has been granted (e.g., "markdown.write", "core.delete")
-   */
-  cap_id: string
-  /**
-   * The target block ID, or "*" for wildcard (all blocks)
-   */
-  block_id: string
-}
+export type Grant = { 
+/**
+ * The editor who has been granted the capability
+ */
+editor_id: string; 
+/**
+ * The capability that has been granted (e.g., "markdown.write", "core.delete")
+ */
+cap_id: string; 
+/**
+ * The target block ID, or "*" for wildcard (all blocks)
+ */
+block_id: string }
 /**
  * Payload for core.grant capability
- *
+ * 
  * This payload is used to grant a capability to an editor for a specific block.
  */
-export type GrantPayload = {
-  /**
-   * The editor ID to grant the capability to
-   */
-  target_editor: string
-  /**
-   * The capability ID to grant (e.g., "markdown.write", "core.delete")
-   */
-  capability: string
-  /**
-   * The block ID to grant access to, or "*" for all blocks (wildcard)
-   */
-  target_block?: string
-}
-export type JsonValue =
-  | null
-  | boolean
-  | number
-  | string
-  | JsonValue[]
-  | Partial<{ [key in string]: JsonValue }>
+export type GrantPayload = { 
+/**
+ * The editor ID to grant the capability to
+ */
+target_editor: string; 
+/**
+ * The capability ID to grant (e.g., "markdown.write", "core.delete")
+ */
+capability: string; 
+/**
+ * The block ID to grant access to, or "*" for all blocks (wildcard)
+ */
+target_block?: string }
+export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 /**
  * Payload for core.link capability
- *
+ * 
  * This payload is used to create a link (relation) from one block to another.
  */
-export type LinkBlockPayload = {
-  /**
-   * The relation type (must be "implement")
-   */
-  relation: string
-  /**
-   * The target block ID to link to
-   */
-  target_id: string
-}
+export type LinkBlockPayload = { 
+/**
+ * The relation type (must be "implement")
+ */
+relation: string; 
+/**
+ * The target block ID to link to
+ */
+target_id: string }
 /**
  * Payload for markdown.write capability
- *
+ * 
  * This payload is used to write markdown content to a markdown block.
  * The content is stored directly as a string in the block's contents.markdown field.
  */
-export type MarkdownWritePayload = {
-  /**
-   * The markdown content to write to the block
-   */
-  content: string
-}
+export type MarkdownWritePayload = { 
 /**
- * Emitted when PTY produces output (high-frequency, from reader thread).
- *
- * The frontend terminal (xterm.js) decodes the base64 data and writes it to the screen.
- * Only emitted by GUI-initiated PTY sessions (not MCP-initiated sessions which
- * only write to the output buffer).
+ * The markdown content to write to the block
  */
-export type PtyOutputEvent = {
-  /**
-   * Base64 encoded output data
-   */
-  data: string
-  /**
-   * The terminal block ID
-   */
-  block_id: string
-}
+content: string }
 /**
  * Payload for core.revoke capability
- *
+ * 
  * This payload is used to revoke a capability from an editor for a specific block.
  */
-export type RevokePayload = {
-  /**
-   * The editor ID to revoke the capability from
-   */
-  target_editor: string
-  /**
-   * The capability ID to revoke
-   */
-  capability: string
-  /**
-   * The block ID to revoke access from, or "*" for all blocks (wildcard)
-   */
-  target_block?: string
-}
+export type RevokePayload = { 
 /**
- * Emitted when backend state changes (e.g., blocks modified via MCP or Tauri commands).
- *
- * The frontend auto-refreshes blocks, grants, and events for the affected file.
- * Sent through the `state_changed_tx` broadcast channel by both Tauri commands
- * and the MCP server after successful command processing.
+ * The editor ID to revoke the capability from
  */
-export type StateChangedEvent = { file_id: string }
+target_editor: string; 
+/**
+ * The capability ID to revoke
+ */
+capability: string; 
+/**
+ * The block ID to revoke access from, or "*" for all blocks (wildcard)
+ */
+target_block?: string }
 /**
  * Full state snapshot at a specific point in time.
  */
-export type StateSnapshot = {
-  /**
-   * Block state at that event
-   */
-  block: Block
-  /**
-   * All grants in the system at that event
-   */
-  grants: Grant[]
-}
+export type StateSnapshot = { 
+/**
+ * Block state at that event
+ */
+block: Block; 
+/**
+ * All grants in the system at that event
+ */
+grants: Grant[] }
 /**
  * Payload for task.commit capability
- *
+ * 
  * Empty payload — target repo is auto-discovered from downstream blocks'
  * `_block_dir` metadata, which links to external git repositories.
  */
@@ -1579,186 +1057,179 @@ export type TaskCommitPayload = Record<string, never>
 /**
  * Result of a task.commit operation.
  */
-export type TaskCommitResult = {
-  /**
-   * Git commit hash
-   */
-  commit_hash: string
-  /**
-   * Git branch name
-   */
-  branch_name: string
-  /**
-   * List of exported file paths
-   */
-  exported_files: string[]
-}
+export type TaskCommitResult = { 
+/**
+ * Git commit hash
+ */
+commit_hash: string; 
+/**
+ * Git branch name
+ */
+branch_name: string; 
+/**
+ * List of exported file paths
+ */
+exported_files: string[] }
 /**
  * Payload for task.read capability
- *
+ * 
  * task.read is a permission-only capability, similar to markdown.read.
  * No payload fields needed — the empty JSON object `{}` is accepted.
  */
 export type TaskReadPayload = Record<string, never>
 /**
  * Payload for task.write capability
- *
+ * 
  * Contains markdown content for a task block.
  * Stored in `contents` as `{ "markdown": "..." }` — same model as markdown blocks.
  * Title is stored in `block.name`, description in `metadata.description`.
  */
-export type TaskWritePayload = {
-  /**
-   * Markdown 内容
-   */
-  content: string
-}
+export type TaskWritePayload = { 
+/**
+ * Markdown 内容
+ */
+content: string }
 /**
  * Payload for terminal.execute capability
- *
+ * 
  * This payload records a command execution in the terminal for audit/history.
  */
-export type TerminalExecutePayload = {
-  /**
-   * The command string that was executed
-   */
-  command: string
-  /**
-   * Exit code of the command (if available)
-   */
-  exit_code: number | null
-}
+export type TerminalExecutePayload = { 
+/**
+ * The command string that was executed
+ */
+command: string; 
+/**
+ * Exit code of the command (if available)
+ */
+exit_code: number | null }
 /**
  * Payload for terminal.init capability
- *
+ * 
  * This payload is used to initialize a PTY session for a terminal block.
  */
-export type TerminalInitPayload = {
-  /**
-   * Number of columns in the terminal
-   */
-  cols: number
-  /**
-   * Number of rows in the terminal
-   */
-  rows: number
-  /**
-   * The terminal block ID
-   */
-  block_id: string
-  /**
-   * The editor initiating the session
-   */
-  editor_id: string
-  /**
-   * The file containing the terminal block (required for permission checking)
-   */
-  file_id: string
-  /**
-   * Optional initial working directory
-   */
-  cwd: string | null
-}
+export type TerminalInitPayload = { 
+/**
+ * Number of columns in the terminal
+ */
+cols: number; 
+/**
+ * Number of rows in the terminal
+ */
+rows: number; 
+/**
+ * The terminal block ID
+ */
+block_id: string; 
+/**
+ * The editor initiating the session
+ */
+editor_id: string; 
+/**
+ * The file containing the terminal block (required for permission checking)
+ */
+file_id: string; 
+/**
+ * Optional initial working directory
+ */
+cwd: string | null }
 /**
  * Payload for terminal.save capability
- *
+ * 
  * This payload is used to save terminal content (buffer snapshot) to a terminal block.
  */
-export type TerminalSavePayload = {
-  /**
-   * The terminal content to save (typically from xterm.js buffer)
-   */
-  saved_content: string
-  /**
-   * Timestamp when the content was saved (ISO 8601 format)
-   */
-  saved_at: string
-}
+export type TerminalSavePayload = { 
+/**
+ * The terminal content to save (typically from xterm.js buffer)
+ */
+saved_content: string; 
+/**
+ * Timestamp when the content was saved (ISO 8601 format)
+ */
+saved_at: string }
 /**
  * Payload for core.unlink capability
- *
+ * 
  * This payload is used to remove a link (relation) from one block to another.
  */
-export type UnlinkBlockPayload = {
-  /**
-   * The relation type (must be "implement")
-   */
-  relation: string
-  /**
-   * The target block ID to unlink
-   */
-  target_id: string
-}
+export type UnlinkBlockPayload = { 
+/**
+ * The relation type (must be "implement")
+ */
+relation: string; 
+/**
+ * The target block ID to unlink
+ */
+target_id: string }
 /**
  * Payload for core.update_metadata capability
- *
+ * 
  * This payload is used to update metadata fields of an existing block.
  * The metadata will be merged with existing metadata (not replaced).
  */
-export type UpdateMetadataPayload = {
-  /**
-   * Metadata fields to update or add
-   * Example: { "description": "Updated description", "tags": ["tag1", "tag2"] }
-   */
-  metadata: JsonValue
-}
+export type UpdateMetadataPayload = { 
+/**
+ * Metadata fields to update or add
+ * Example: { "description": "Updated description", "tags": ["tag1", "tag2"] }
+ */
+metadata: JsonValue }
 
 /** tauri-specta globals **/
 
 import {
-  invoke as TAURI_INVOKE,
-  Channel as TAURI_CHANNEL,
-} from '@tauri-apps/api/core'
-import * as TAURI_API_EVENT from '@tauri-apps/api/event'
-import { type WebviewWindow as __WebviewWindow__ } from '@tauri-apps/api/webviewWindow'
+	invoke as TAURI_INVOKE,
+	Channel as TAURI_CHANNEL,
+} from "@tauri-apps/api/core";
+import * as TAURI_API_EVENT from "@tauri-apps/api/event";
+import { type WebviewWindow as __WebviewWindow__ } from "@tauri-apps/api/webviewWindow";
 
 type __EventObj__<T> = {
-  listen: (
-    cb: TAURI_API_EVENT.EventCallback<T>
-  ) => ReturnType<typeof TAURI_API_EVENT.listen<T>>
-  once: (
-    cb: TAURI_API_EVENT.EventCallback<T>
-  ) => ReturnType<typeof TAURI_API_EVENT.once<T>>
-  emit: null extends T
-    ? (payload?: T) => ReturnType<typeof TAURI_API_EVENT.emit>
-    : (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>
-}
+	listen: (
+		cb: TAURI_API_EVENT.EventCallback<T>,
+	) => ReturnType<typeof TAURI_API_EVENT.listen<T>>;
+	once: (
+		cb: TAURI_API_EVENT.EventCallback<T>,
+	) => ReturnType<typeof TAURI_API_EVENT.once<T>>;
+	emit: null extends T
+		? (payload?: T) => ReturnType<typeof TAURI_API_EVENT.emit>
+		: (payload: T) => ReturnType<typeof TAURI_API_EVENT.emit>;
+};
 
 export type Result<T, E> =
-  | { status: 'ok'; data: T }
-  | { status: 'error'; error: E }
+	| { status: "ok"; data: T }
+	| { status: "error"; error: E };
 
 function __makeEvents__<T extends Record<string, any>>(
-  mappings: Record<keyof T, string>
+	mappings: Record<keyof T, string>,
 ) {
-  return new Proxy(
-    {} as unknown as {
-      [K in keyof T]: __EventObj__<T[K]> & {
-        (handle: __WebviewWindow__): __EventObj__<T[K]>
-      }
-    },
-    {
-      get: (_, event) => {
-        const name = mappings[event as keyof T]
+	return new Proxy(
+		{} as unknown as {
+			[K in keyof T]: __EventObj__<T[K]> & {
+				(handle: __WebviewWindow__): __EventObj__<T[K]>;
+			};
+		},
+		{
+			get: (_, event) => {
+				const name = mappings[event as keyof T];
 
-        return new Proxy((() => {}) as any, {
-          apply: (_, __, [window]: [__WebviewWindow__]) => ({
-            listen: (arg: any) => window.listen(name, arg),
-            once: (arg: any) => window.once(name, arg),
-            emit: (arg: any) => window.emit(name, arg),
-          }),
-          get: (_, command: keyof __EventObj__<any>) => {
-            switch (command) {
-              case 'listen':
-                return (arg: any) => TAURI_API_EVENT.listen(name, arg)
-              case 'once':
-                return (arg: any) => TAURI_API_EVENT.once(name, arg)
-              case 'emit':
-                return (arg: any) => TAURI_API_EVENT.emit(name, arg)
-            }
-          },
-        })
-      },
-    }
-  )
+				return new Proxy((() => {}) as any, {
+					apply: (_, __, [window]: [__WebviewWindow__]) => ({
+						listen: (arg: any) => window.listen(name, arg),
+						once: (arg: any) => window.once(name, arg),
+						emit: (arg: any) => window.emit(name, arg),
+					}),
+					get: (_, command: keyof __EventObj__<any>) => {
+						switch (command) {
+							case "listen":
+								return (arg: any) => TAURI_API_EVENT.listen(name, arg);
+							case "once":
+								return (arg: any) => TAURI_API_EVENT.once(name, arg);
+							case "emit":
+								return (arg: any) => TAURI_API_EVENT.emit(name, arg);
+						}
+					},
+				});
+			},
+		},
+	);
 }


### PR DESCRIPTION
  Body:                                                                                                                 
  ## Summary                                                                                                            
                                                                                                                        
  - 使用 `ignore` crate 的 `WalkBuilder` 替换 `walkdir`，导入目录时自动读取并应用 `.gitignore`                          
  规则（支持嵌套子目录）                                                                         
  - `ScanOptions.ignore_patterns` 字段，补全过滤规则                         
  - 补全 `infer_block_type` 二进制黑名单（Office 文档、字体、3D 资产、应用包等），修复 `DS_Store` 大小写匹配 bug        
                                                                                                                        
  ## Test plan                                                                                                          
                                                                                                                        
  - [x] 7 个 fs_scanner 单元测试全部通过（含 3 个新增：gitignore 生效、嵌套 gitignore、gitignore 禁用）                 
  - [x] 4 个 block_type_inference 单元测试通过                                                                          
  - [x] 全量 319 + 42 集成测试通过，0 失败                                                                              
  - [x] 手动导入含 `.gitignore` 的 Node/Rust 项目，验证 `node_modules`/`target` 被正确跳过                              
  - [x] 手动导入不含 `.gitignore` 的目录，验证所有文本文件正常导入    