### PR TITLE
feat(sync): Session Sync Module with notify-debouncer-mini

### DIFF
--- a/docs/mvp/changelog/CHANGELOG-SESSION-SYNC-REFACTORING.md
+++ b/docs/mvp/changelog/CHANGELOG-SESSION-SYNC-REFACTORING.md
@@ -1,0 +1,212 @@
+# Changelog: Session Sync 模块重构
+
+> **分支**: `session-directory`
+> **日期**: 2026-02-05
+> **变更规模**: 3 个文件修改 + 新增测试
+
+---
+
+## 概述
+
+根据需求文档 `docs/mvp/phase2/plans/session-sync.md` 对 Session Sync 模块进行重构和完善。主要改进：
+
+1. **将文件监听器升级为使用 `notify-debouncer-mini`**：在 watcher 层实现 100ms 防抖，替代原本在事件循环中的延时处理
+2. **修复内存泄漏**：移除 `std::mem::forget(notify_tx)` 的 hack 实现
+3. **补充单元测试**：新增 5 个测试用例，覆盖 metadata 提取、序列化往返、offset 持久化等场景
+
+---
+
+## 变更文件
+
+### 1. `src-tauri/src/sync/watcher.rs`
+
+**主要改动**：升级为使用 `notify-debouncer-mini` 实现 100ms 防抖
+
+| 变更点 | 原实现 | 新实现 |
+|--------|--------|--------|
+| Watcher 类型 | `RecommendedWatcher` | `Debouncer<notify::RecommendedWatcher>` |
+| 事件类型 | `NotifyEvent` | `Vec<DebouncedEvent>` |
+| 防抖实现 | 无（在 mod.rs 中 sleep 100ms） | watcher 层内置 100ms 防抖 |
+| 内存管理 | `std::mem::forget(notify_tx)` | 正常 ownership 转移 |
+
+**代码变更**：
+
+```rust
+// 依赖导入变更
+- use notify::{Event as NotifyEvent, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
++ use notify::RecursiveMode;
++ use notify_debouncer_mini::{new_debouncer, DebouncedEvent, Debouncer, DebouncedEventKind};
++ use std::time::Duration;
+
+// SessionWatcher 结构体
+pub struct SessionWatcher {
+-   watcher: RecommendedWatcher,
++   watcher: Debouncer<notify::RecommendedWatcher>,
+    // ...
+}
+
+// 创建 watcher
+- let watcher = RecommendedWatcher::new(...)
++ let watcher = new_debouncer(Duration::from_millis(100), move |res| { ... })
+
+// 访问内部 watcher
+- self.watcher.watch(&session_dir, ...)
++ self.watcher.watcher().watch(&session_dir, ...)
+```
+
+### 2. `src-tauri/src/sync/mod.rs`
+
+**改动**：移除冗余的防抖延时
+
+```rust
+// 事件循环中移除 sleep
+while let Some(event) = event_rx.recv().await {
+    println!("[SessionSync] Received event for: {}", event.path.display());
+
+-   // Debounce: small delay to coalesce rapid writes
+-   tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
++   // Note: Debouncing is handled by notify-debouncer-mini in the watcher (100ms).
++   // No need for additional delay here.
+
+    // 1. Parse incrementally
+    // ...
+}
+```
+
+### 3. `src-tauri/src/sync/tests.rs`
+
+**新增测试用例**：
+
+| 测试名称 | 验证内容 |
+|----------|----------|
+| `test_metadata_extraction` | 验证从 JSONL 提取 model、version、git_branch、cwd、started_at |
+| `test_session_data_round_trip` | 验证 SessionData JSON 序列化/反序列化一致性 |
+| `test_offset_persistence_and_restore` | 验证 parser offset 可以正确保存和恢复 |
+| `test_system_message_skipped` | 验证 `type: "system"` 消息被正确过滤 |
+| `test_result_message_skipped` | 验证 `type: "result"` 消息被正确过滤 |
+
+---
+
+## 验收标准对照
+
+| AC 编号 | 描述 | 状态 | 验证方式 |
+|---------|------|------|----------|
+| AC-01 | 路径编码正确（Unix + Windows，含大小写兼容） | ✅ | 7 个单元测试 |
+| AC-02 | 从 Agent config_dir 正确推算 session 目录 | ✅ | `test_config_dir_to_session_dir` |
+| AC-04 | 增量解析只处理新增行 | ✅ | `test_incremental_parse_only_new_lines` |
+| AC-05 | user 消息正确转换 | ✅ | `test_parse_user_message` |
+| AC-06 | assistant 消息（text/tool_use）正确转换 | ✅ | `test_parse_assistant_message`, `test_assistant_with_tool_use_preserved` |
+| AC-07 | thinking/progress/snapshot 正确跳过 | ✅ | `test_file_history_snapshot_skipped`, `test_summary_skipped`, `test_system_message_skipped`, `test_result_message_skipped` |
+
+---
+
+## 模块结构
+
+重构后模块结构保持不变，与需求文档一致：
+
+```
+src-tauri/src/sync/
+├── mod.rs           # 模块入口 + SessionSyncManager
+├── session_path.rs  # Session 目录路径计算器
+├── watcher.rs       # JSONL 文件监听器（notify-debouncer-mini）
+├── parser.rs        # JSONL 增量解析器 + JSON 转换
+├── writer.rs        # Session Block 写入器（Markdown Block）
+└── tests.rs         # 集成测试
+```
+
+---
+
+## 测试结果
+
+```
+running 30 tests
+test sync::parser::tests::test_missing_type_returns_none ... ok
+test sync::parser::tests::test_progress_message_preserved ... ok
+test sync::parser::tests::test_optional_fields_omitted ... ok
+test sync::parser::tests::test_parse_user_message ... ok
+test sync::parser::tests::test_summary_skipped ... ok
+test sync::parser::tests::test_assistant_with_tool_use_preserved ... ok
+test sync::parser::tests::test_session_data_serialization ... ok
+test sync::parser::tests::test_file_history_snapshot_skipped ... ok
+test sync::parser::tests::test_parse_assistant_message ... ok
+test sync::session_path::tests::* ... ok (7 tests)
+test sync::tests::* ... ok (14 tests)
+
+test result: ok. 30 passed; 0 failed; 0 ignored
+```
+
+---
+
+## 依赖说明
+
+已在 `Cargo.toml` 中声明（无需新增）：
+
+```toml
+# Session sync (file system watching)
+notify = "7"
+notify-debouncer-mini = "0.5"
+```
+
+---
+
+## 追加修复：Session 目录不存在时的处理
+
+### 问题
+
+原实现：当 `~/.claude/projects/{encoded-path}/` 目录不存在时，状态设为 `Stopped`，不监听。
+
+**后果**：用户首次在该项目使用 Claude Code 时，目录会被创建，但我们不会感知到，同步不会自动启动。
+
+### 解决方案
+
+新增 `WaitingForDirectory` 状态，当目标目录不存在时：
+
+1. 监听父目录 `~/.claude/projects/`（递归模式）
+2. 将 Agent 添加到 `pending_agents` 列表
+3. 状态设为 `WaitingForDirectory`
+4. 当目标子目录被创建时，自动切换到监听该子目录，状态变为 `Watching`
+
+### 代码变更
+
+**watcher.rs**：
+
+```rust
+/// Session sync status for an Agent.
+pub enum SyncStatus {
+    Watching,
+    WaitingForDirectory,  // 新增
+    Stopped,
+    Error(String),
+}
+
+/// Pending agent waiting for its session directory to be created.
+pub(crate) struct PendingAgent {
+    pub file_id: String,
+    pub agent_block_id: String,
+    pub config_dir: String,
+    pub expected_session_dir: PathBuf,
+}
+
+pub struct SessionWatcher {
+    // ...
+    pending_agents: Arc<StdMutex<Vec<PendingAgent>>>,  // 新增
+    watching_parent: Arc<StdMutex<bool>>,              // 新增
+}
+
+impl SessionWatcher {
+    /// 确保监听父目录
+    fn ensure_watching_parent(&mut self) -> Result<(), String> { ... }
+}
+```
+
+### 行为对比
+
+| 场景 | 原行为 | 新行为 |
+|------|--------|--------|
+| Session 目录存在 | 监听 + Watching | 监听 + Watching（不变） |
+| Session 目录不存在 | Stopped，不监听 | WaitingForDirectory，监听父目录 |
+| 用户首次使用 Claude Code | 不会检测到 | 自动检测目录创建，切换到 Watching |
+
+---
+
+**最后更新**: 2026-02-05

--- a/docs/mvp/phase2/plans/session-sync.md
+++ b/docs/mvp/phase2/plans/session-sync.md
@@ -1,0 +1,1332 @@
+# 3.4 Session 同步模块 — 开发需求文档
+
+> 日期: 2026-02-04（v2，基于代码实际验证更新）
+> 预估总工时: 14 人时（路径计算 2h + 文件监听 4h + 增量解析 4h + Block 写入 4h）
+> 前置条件: .elf/ Dir Block 初始化已完成（I10-01 ✅，`elf_meta.rs` 中已预置 `session/` 目录）
+> 并行条件: 不依赖 3.1 Agent / 3.2 MCP，可独立开发；3.3 Skills 不阻塞本模块
+> 输出目录: `src-tauri/src/sync/` (新建模块)
+
+---
+
+## 一、模块目标
+
+将 Claude Code 在外部项目中产生的 Session 数据（JSONL 格式）自动同步到 Elfiee 的 `.elf/` 内部存储，**解析为可读性强的 Markdown 文档**并入库。
+
+### 三大核心功能
+
+| # | 功能 | 说明 |
+|---|------|------|
+| **F1** | **根据 Agent 配置找到 Session 目录** | 从 Agent Block 的 `config_dir` 字段推算 `~/.claude/projects/{encoded-path}/` |
+| **F2** | **监听聊天内容变更** | 使用 `notify` crate 监听 Session 目录下 `.jsonl` 文件的新增/修改 |
+| **F3** | **读取聊天内容，parse 成可读文档，Block 入库** | 增量解析 JSONL，转换为 Markdown 格式的会话记录，存储为 Markdown Block |
+
+### 设计目标
+
+1. **AI 会话可追溯**：每次 Claude Code 交互记录持久化到 .elf 文件
+2. **可读性优先**：原始 JSONL 转换为 Markdown 文档，方便人类阅读和 AI 引用
+3. **增量同步**：只解析新增 JSONL 行，避免重复处理
+4. **自动触发**：监听文件系统变化，无需用户手动操作
+
+### 用户操作流程
+
+用户**不需要手动操作** Session 同步。唯一的触发点是 Agent 的启用/禁用，同步完全在后台自动进行。
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ 1. 用户创建 Agent                                                │
+│    在 Elfiee 中执行 agent.create(config_dir: ".claude/")         │
+│    → 创建 Agent Block，绑定到外部项目的 AI 工具配置目录             │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 2. 用户启用 Agent                                                │
+│    执行 agent.enable(agent_block_id)                             │
+│    → 创建 symlink + 注入 MCP 配置（已有逻辑）                      │
+│    → 【自动启动】Session 同步（本模块新增）                         │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 3. 后台自动运行（用户无感知）                                       │
+│                                                                 │
+│    a. 从 Agent config_dir 推算 session 目录                       │
+│       "D:\workspace\elfiee\.claude"                              │
+│       → parent: "D:\workspace\elfiee"                            │
+│       → 编码: "d--workspace-elfiee"                               │
+│       → 目录: ~/.claude/projects/d--workspace-elfiee/             │
+│                                                                 │
+│    b. 监听该目录下所有 .jsonl 文件的新增和修改                       │
+│                                                                 │
+│    c. 检测到变更 → 增量读取新行 → 解析 JSONL → 转换为 Markdown       │
+│       - user 消息    → "## User (时间)\n\n内容"                    │
+│       - assistant 回复 → "## Assistant (时间)\n\n内容"              │
+│       - tool_use      → "> **Tool Use**: 工具名 — 描述"           │
+│       - thinking/progress → 跳过（内部数据，不展示）                 │
+│                                                                 │
+│    d. 写入 .elf/session/{project}/session_{id}.md (Markdown Block) │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 4. 用户在 Elfiee 中查看 Session 记录                               │
+│    .elf/ → session/ → elfiee/ → session_xxxx.md                  │
+│    内容为可读的 Markdown 格式对话记录，前端直接渲染                    │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ 5. 用户禁用 Agent（可选）                                         │
+│    执行 agent.disable(agent_block_id)                            │
+│    → 清理 symlink + 移除 MCP 配置（已有逻辑）                      │
+│    → 【自动停止】Session 同步                                     │
+│    → 已同步的 Session Block 保留在 .elf/ 中，不删除                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**自动恢复**：用户重新打开 .elf 文件时，系统扫描所有已启用的 Agent Block，自动恢复 Session 同步（从上次偏移量继续）。
+
+---
+
+## 二、现状确认
+
+### 2.1 已完成的基础设施
+
+| 组件 | 状态 | 位置 |
+|------|------|------|
+| .elf/ Dir Block 初始化 | ✅ | `extensions/directory/elf_meta.rs` |
+| `session/` 虚拟目录 | ✅ | `elf_meta.rs:93` (`EXTRA_DIRS` 包含 `"session/"`) |
+| Agent Block (含 `config_dir`) | ✅ | `extensions/agent/mod.rs:51-79` |
+| code.write Capability | ✅ | `extensions/code/code_write.rs` |
+| markdown.write Capability | ✅ | `extensions/markdown/markdown_write.rs` |
+| core.create Capability | ✅ | `capabilities/builtins/create.rs` |
+| directory.write Capability | ✅ | `extensions/directory/directory_write.rs` |
+| EngineHandle.process_command() | ✅ | `engine/actor.rs` |
+| AppState（多文件管理） | ✅ | `state.rs` |
+| BlockMetadata.custom 扩展字段 | ✅ | `models/metadata.rs` |
+
+### 2.2 需要新增
+
+| 模块 | 说明 |
+|------|------|
+| `sync/mod.rs` | 模块入口，导出公开接口 + SessionSyncManager |
+| `sync/session_path.rs` | Session 目录路径计算器（从 Agent config_dir 推算） |
+| `sync/watcher.rs` | JSONL 文件监听器 |
+| `sync/parser.rs` | JSONL 增量解析器 + Markdown 转换器 |
+| `sync/writer.rs` | Session Block 写入器（Markdown Block） |
+| `sync/tests.rs` | 单元测试 + 集成测试 |
+
+### 2.3 需要新增的依赖
+
+```toml
+# Cargo.toml [dependencies]
+notify = "7"          # 跨平台文件系统监听（inotify/FSEvents/ReadDirectoryChanges）
+```
+
+---
+
+## 三、Claude Code Session 文件格式（实际验证）
+
+> **重要**：以下内容基于在 Windows 开发机上实际检查 `~/.claude/projects/` 目录得出，纠正了 v1 文档中的多处推测。
+
+### 3.1 目录结构
+
+```
+~/.claude/
+└── projects/
+    └── {encoded-path}/              # 路径编码（见下文）
+        ├── {session-uuid}.jsonl     # 完整会话记录
+        ├── {session-uuid}/          # 部分 session 有同名目录
+        └── ...
+```
+
+**实际目录示例**（本机 `C:/Users/Lenovo/.claude/projects/`）：
+
+```
+d--workspace-zhidaoyuan-elfiee/          # 本项目
+D--workspace-zhidaoyuan-elfiee-peoject-elfiee/
+D--workspace-zhidaoyuan-frontend-component-library/
+C--Users-Lenovo-AppData-Local-Temp--tmp6mKgVe/
+```
+
+### 3.2 路径编码规则（已验证）
+
+Windows 路径 `D:\workspace\zhidaoyuan\elfiee` 的编码结果：
+
+```
+D:\workspace\zhidaoyuan\elfiee
+↓ Step 1: 将 `\` 替换为 `-`
+D:-workspace-zhidaoyuan-elfiee
+↓ Step 2: 将 `:` 替换为 `-`
+D--workspace-zhidaoyuan-elfiee
+↓ Step 3: 驱动器号可能小写
+d--workspace-zhidaoyuan-elfiee
+```
+
+**关键发现**：
+- Windows 下 `:` 替换为 `-`，与 `\` 的 `-` 连续产生 `--`（`D:\` → `D-` + `-workspace` = `D--workspace`）
+- 驱动器号**可能小写**（观察到 `d--` 和 `D--` 共存，需兼容两种）
+- Unix 下 `/` 替换为 `-`，前缀保留 `-`（如 `-home-yaosh-projects-elfiee`）
+
+**兼容策略**：查找 Session 目录时，同时检查大小写变体。
+
+### 3.3 JSONL 行格式（实际验证）
+
+每行一个 JSON 对象。**实际格式比 v1 文档丰富得多**，主要类型：
+
+#### 类型一览
+
+| `type` 字段 | 说明 | 出现频率 |
+|-------------|------|----------|
+| `user` | 用户消息 | 高频 |
+| `assistant` | AI 回复（可含多个 content block：text/thinking/tool_use） | 高频 |
+| `progress` | Agent 子任务进展（嵌套的 agent 消息） | 高频 |
+| `file-history-snapshot` | 文件快照记录 | 每条会话开头 |
+| `summary` | 会话摘要 | 低频 |
+| `system` | 系统消息 | 低频 |
+| `result` | 工具执行结果 | 中频 |
+
+#### 实际 JSONL 样例
+
+**用户消息**：
+```json
+{
+  "type": "user",
+  "message": {"role": "user", "content": "请帮我检查下现在的代码..."},
+  "timestamp": "2026-02-03T06:46:50.519Z",
+  "sessionId": "26b41bcf-ed62-4f38-a04f-cfb4e6fd38b9",
+  "cwd": "D:\\workspace\\zhidaoyuan\\elfiee",
+  "version": "2.1.29",
+  "gitBranch": "dev",
+  "uuid": "9585ee50-...",
+  "parentUuid": null
+}
+```
+
+**AI 回复（含 thinking + tool_use）**：
+```json
+{
+  "type": "assistant",
+  "message": {
+    "model": "claude-opus-4-5-20251101",
+    "role": "assistant",
+    "content": [
+      {"type": "thinking", "thinking": "The user is asking me to analyze..."},
+      {"type": "text", "text": "Let me analyze the code..."},
+      {"type": "tool_use", "id": "toolu_019Be1...", "name": "Task", "input": {"description": "Explore import flow code", "prompt": "..."}}
+    ],
+    "usage": {"input_tokens": 3, "output_tokens": 10}
+  },
+  "timestamp": "2026-02-03T06:46:55.797Z",
+  "uuid": "c434653a-...",
+  "parentUuid": "9585ee50-..."
+}
+```
+
+**Agent 进展消息**：
+```json
+{
+  "type": "progress",
+  "data": {
+    "type": "agent_progress",
+    "prompt": "I need to understand the full import flow...",
+    "agentId": "ab75dbd",
+    "message": {"type": "assistant", "message": {"role": "assistant", "content": [...]}}
+  },
+  "toolUseID": "agent_msg_014a3D37...",
+  "parentToolUseID": "toolu_019Be1wY...",
+  "timestamp": "2026-02-03T06:47:09.133Z"
+}
+```
+
+### 3.4 关键字段说明
+
+| 字段 | 说明 | 用于 Markdown 生成 |
+|------|------|--------------------|
+| `type` | 消息类型 | 决定 Markdown 标题和分区 |
+| `message.role` | `user` / `assistant` | 对话角色标识 |
+| `message.content` | 字符串或结构化数组 | **核心内容来源** |
+| `message.content[].type` | `text` / `thinking` / `tool_use` / `tool_result` | 内容块分类 |
+| `message.model` | AI 模型标识 | Markdown 元信息 |
+| `timestamp` | ISO 8601 UTC | 时间排序和展示 |
+| `sessionId` | Session UUID | 分组和文件关联 |
+| `uuid` / `parentUuid` | 消息树结构 | 保持对话层级 |
+| `cwd` | 工作目录 | Session 元信息 |
+| `gitBranch` | Git 分支 | Session 元信息 |
+| `version` | Claude Code 版本 | Session 元信息 |
+
+### 3.5 Session 文件特征
+
+- 文件名即 Session ID：`{uuid}.jsonl`
+- 追加写入：新消息追加到文件末尾
+- 同时存在多个 session 文件（本项目有 ~190 个）
+- 文件在 Claude Code 运行期间持续增长
+- 大文件可达 1900+ 行（单个长会话）
+- 部分 session 有同名目录（`{uuid}/`），功能未知，**只处理 `.jsonl` 文件**
+
+---
+
+## 四、架构设计
+
+### 4.1 总体流程
+
+```
+                  ┌──────────────┐
+                  │ Claude Code  │
+                  │  (外部进程)   │
+                  └──────┬───────┘
+                         │ 追加 JSONL
+                         ▼
+    ~/.claude/projects/{path}/{uuid}.jsonl
+                         │
+        ┌────────────────┤
+        │                │
+    F1: 路径计算     F2: notify 监听
+    (从 Agent        (文件变更事件)
+     config_dir)         │
+        │                ▼
+        │     ┌──────────────────┐
+        └────→│  SessionWatcher  │  ← sync/watcher.rs
+              │  (tokio task)    │
+              └──────────┬───────┘
+                         │ FileChangeEvent
+                         ▼
+              ┌──────────────────┐
+              │ SessionParser    │  ← sync/parser.rs
+              │ (增量解析 JSONL  │
+              │  → Markdown 转换)│
+              └──────────┬───────┘
+                         │ 结构化 Markdown
+                         ▼
+              ┌──────────────────┐
+              │ SessionWriter    │  ← sync/writer.rs
+              │ (写入 Markdown   │
+              │  Block 到 .elf/) │
+              └──────────┬───────┘
+                         │ process_command
+                         ▼
+              ┌──────────────────┐
+              │ ElfileEngine     │  ← engine/actor.rs
+              │ (事件溯源)       │
+              └──────────────────┘
+```
+
+### 4.2 F1：从 Agent 配置找到 Session 目录
+
+**数据来源**：Agent Block 的 `config_dir` 字段。
+
+```
+AgentContents.config_dir = "D:\\workspace\\zhidaoyuan\\elfiee\\.claude"
+                                    ↓ 取 parent 得到项目路径
+                 project_path = "D:\\workspace\\zhidaoyuan\\elfiee"
+                                    ↓ 路径编码
+                   encoded = "d--workspace-zhidaoyuan-elfiee"
+                                    ↓ 组合
+         session_dir = ~/.claude/projects/d--workspace-zhidaoyuan-elfiee/
+```
+
+**为什么不用 Directory Block 的 `external_root_path`**：
+- Agent 是 Session 同步的逻辑主体（一个 Agent 对应一个外部项目的 AI 集成）
+- `config_dir` 已包含足够信息推算项目路径
+- Agent enable/disable 直接控制 Session 同步的启停
+
+### 4.3 F2：文件变更监听
+
+- 使用 `notify` crate 监听 `.jsonl` 文件的 Create/Modify 事件
+- 支持同时监听多个 Agent 关联的不同项目
+- debounce 100ms 合并连续写入事件
+- 首次启动时全量扫描已有文件
+
+### 4.4 F3：解析为可读文档并入库
+
+**核心变更**：v1 存储原始 JSONL 为 Code Block → v2 转换为 Markdown → v3 简化 JSON → **v4 保留原始字段的 JSON**。
+
+**JSON 输出格式**：
+
+保留原始 JSONL 的关键字段：`type`、`message`、`timestamp`、`version`、`gitBranch`、`data`。
+
+```json
+{
+  "session_id": "26b41bcf-ed62-4f38-a04f-cfb4e6fd38b9",
+  "project": "elfiee",
+  "messages": [
+    {
+      "type": "user",
+      "message": {"role": "user", "content": "请帮我检查下现在的代码..."},
+      "timestamp": "2026-02-03T06:46:50.519Z",
+      "version": "2.1.29",
+      "gitBranch": "dev"
+    },
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-opus-4-5-20251101",
+        "role": "assistant",
+        "content": [
+          {"type": "thinking", "thinking": "Let me analyze..."},
+          {"type": "text", "text": "Let me先查看相关的 store 实现..."},
+          {"type": "tool_use", "id": "toolu_xxx", "name": "Task", "input": {...}}
+        ],
+        "usage": {"input_tokens": 3, "output_tokens": 10}
+      },
+      "timestamp": "2026-02-03T06:46:55.797Z"
+    },
+    {
+      "type": "progress",
+      "data": {"type": "agent_progress", "agentId": "abc123", "message": {...}},
+      "timestamp": "2026-02-03T06:47:09.133Z"
+    }
+  ]
+}
+```
+
+**保留的字段**：
+
+| 字段 | 说明 |
+|------|------|
+| `type` | 消息类型：`user`、`assistant`、`progress` 等 |
+| `message` | 完整的 message 对象（包含 content、model、usage 等） |
+| `timestamp` | ISO 8601 时间戳 |
+| `version` | Claude Code 版本号 |
+| `gitBranch` | Git 分支名 |
+| `data` | progress 消息的数据（包含 agent 子任务信息） |
+
+**跳过的消息类型**：
+- `file-history-snapshot` — 文件快照（每个 session 开头）
+- `summary` — 会话摘要
+- `system` — 系统消息
+- `result` — 执行结果
+
+### 4.5 存储设计
+
+Session 数据存储为 **Markdown Block**（`block_type: "markdown"`），内容为 **JSON 字符串**，原因：
+- 结构化数据，便于程序解析和 AI 引用
+- JSON 格式支持增量追加 messages 数组
+- 复用现有 `markdown.write` Capability（content 字段存储 JSON 文本）
+- 快照机制自动生成 `block-{uuid}/body.md` 物理文件（实际内容为 JSON）
+- 前端可解析 JSON 并渲染为对话列表
+
+**Block 命名规范**：
+- Block name: `session_{session_id}` （如 `session_26b41bcf-ed62-4f38-a04f-cfb4e6fd38b9`）
+- Block metadata.description: `"Claude Code session for {project-name} ({branch})"`
+- Block metadata.custom:
+  ```json
+  {
+    "session_id": "26b41bcf-...",
+    "project_name": "elfiee",
+    "config_dir": "D:\\workspace\\zhidaoyuan\\elfiee\\.claude",
+    "source_file": "C:/Users/Lenovo/.claude/projects/d--workspace-zhidaoyuan-elfiee/26b41bcf-....jsonl",
+    "sync_offset": 12345,
+    "model": "claude-opus-4-5-20251101",
+    "git_branch": "dev",
+    "message_count": 42,
+    "last_synced_at": "2026-02-03T06:50:00Z"
+  }
+  ```
+
+### 4.6 生命周期管理
+
+```
+SessionSyncManager (顶层管理器)
+├── start_sync(file_id, agent_block_id) → 从 Agent 配置启动监听
+├── stop_sync(agent_block_id)           → 停止监听
+└── get_sync_status(agent_block_id)     → 查询状态
+
+SessionWatcher (每个 Agent 一个监听)
+├── watch()   → 开始监听 session 目录
+├── unwatch() → 停止监听
+└── status()  → 当前状态 (watching/stopped/error)
+```
+
+**触发时机**：
+- `agent.enable` 时：根据 Agent 的 `config_dir` 启动 Session 同步
+- `agent.disable` 时：停止该 Agent 关联的 Session 同步
+- `open_file` 时：扫描所有已启用的 Agent Block，恢复 Session 同步
+- `close_file` 时：停止该文件关联的所有同步
+
+---
+
+## 五、详细任务分解
+
+### 5.1 F10-01: Session 目录计算器（2 人时）
+
+**文件**: `src-tauri/src/sync/session_path.rs`
+
+**功能描述**：
+根据 Agent Block 的 `config_dir` 推算对应的 Claude Code session 目录。
+
+**输入/输出**：
+```rust
+/// 从 Agent 的 config_dir 推算 Session 目录
+///
+/// # 推算流程
+/// 1. 从 config_dir 取 parent 得到 project_path
+///    例: "D:\\workspace\\zhidaoyuan\\elfiee\\.claude" → "D:\\workspace\\zhidaoyuan\\elfiee"
+/// 2. 对 project_path 应用路径编码
+/// 3. 组合为 `~/.claude/projects/{encoded}/`
+///
+/// # 路径编码规则（已验证）
+/// - Unix: `/home/yaosh/projects/elfiee` → `-home-yaosh-projects-elfiee`
+/// - Windows: `D:\workspace\zhidaoyuan\elfiee` → `d--workspace-zhidaoyuan-elfiee`
+///   - `\` 替换为 `-`
+///   - `:` 移除（产生连续 `--`）
+///   - 驱动器号**可能小写**
+///
+/// # Returns
+/// - `Ok(PathBuf)`: session 目录路径
+/// - `Err(String)`: config_dir 无 parent 或 home 不可用
+pub fn compute_session_dir_from_config(config_dir: &str) -> Result<PathBuf, String>
+
+/// 直接从外部项目路径计算 Session 目录（兼容接口）
+pub fn compute_session_dir(external_path: &Path) -> Result<PathBuf, String>
+```
+
+**实现要点**：
+
+1. **从 config_dir 提取项目路径**：`Path::new(config_dir).parent()`
+2. **路径编码**：
+   - 取绝对路径字符串
+   - 将 `\` 替换为 `-`
+   - 将 `/` 替换为 `-`
+   - 将 `:` 替换为 `-`（与 `\` 的 `-` 连续产生 `D:` → `D-` + `-` = `D--`）
+   - **不添加** `-` 前缀（Windows 编码结果已自然以盘符开头）
+   - Unix 路径因以 `/` 开头，编码后自然以 `-` 开头
+3. **大小写兼容**：查找目录时，先尝试原始编码，再尝试小写变体
+4. **组合路径**：`{home}/.claude/projects/{encoded-path}/`
+
+**辅助函数**：
+```rust
+/// 对路径应用 Claude Code 的编码规则
+///
+/// 实际验证结果：
+/// - "D:\workspace\zhidaoyuan\elfiee" → "D--workspace-zhidaoyuan-elfiee"
+/// - "/home/yaosh/projects/elfiee" → "-home-yaosh-projects-elfiee"
+pub fn encode_project_path(path: &Path) -> String
+
+/// 从编码路径反解出项目名称（取最后一段 `-` 分隔的名称）
+/// 例如: "d--workspace-zhidaoyuan-elfiee" → "elfiee"
+pub fn extract_project_name(encoded_path: &str) -> String
+
+/// 检查 session 目录是否存在（兼容大小写）
+/// 返回实际存在的路径或 None
+pub fn find_session_dir(external_path: &Path) -> Option<PathBuf>
+```
+
+**测试用例**：
+```rust
+#[test] fn test_unix_path_encoding()
+    // "/home/yaosh/projects/elfiee" → "-home-yaosh-projects-elfiee"
+
+#[test] fn test_windows_path_encoding()
+    // "D:\workspace\zhidaoyuan\elfiee" → "D--workspace-zhidaoyuan-elfiee"
+
+#[test] fn test_windows_colon_removed_not_replaced()
+    // 验证 `:` 移除而非替换为 `-`
+
+#[test] fn test_config_dir_to_session_dir()
+    // "D:\workspace\zhidaoyuan\elfiee\.claude" → session dir 正确
+
+#[test] fn test_extract_project_name()
+    // "d--workspace-zhidaoyuan-elfiee" → "elfiee"
+
+#[test] fn test_extract_project_name_unix()
+    // "-home-yaosh-projects-elfiee" → "elfiee"
+```
+
+---
+
+### 5.2 F11-01: JSONL 文件监听器（4 人时）
+
+**文件**: `src-tauri/src/sync/watcher.rs`
+
+**功能描述**：
+使用 `notify` crate 监听 Claude Code session 目录下所有 `.jsonl` 文件的变更，支持多 Agent 同时监听。
+
+**核心结构**：
+```rust
+use notify::{RecommendedWatcher, RecursiveMode, Watcher, Event as NotifyEvent};
+use tokio::sync::mpsc;
+use std::path::PathBuf;
+use std::collections::HashMap;
+
+/// Session 同步状态
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+pub enum SyncStatus {
+    /// 正在监听
+    Watching,
+    /// 已停止（目录不存在或手动停止）
+    Stopped,
+    /// 错误状态
+    Error(String),
+}
+
+/// 文件变更事件（发送给 Parser）
+#[derive(Debug)]
+pub struct FileChangeEvent {
+    /// 变更的 JSONL 文件路径
+    pub path: PathBuf,
+    /// 关联的 Agent Block ID
+    pub agent_block_id: String,
+    /// 关联的 .elf file_id
+    pub file_id: String,
+    /// Agent 的 config_dir（用于推算 project_name）
+    pub config_dir: String,
+}
+
+/// Session 文件监听器
+pub struct SessionWatcher {
+    /// notify watcher 实例
+    watcher: RecommendedWatcher,
+    /// 变更事件发送端
+    event_tx: mpsc::UnboundedSender<FileChangeEvent>,
+    /// 已监听的目录映射：session_dir → (file_id, agent_block_id, config_dir)
+    watched_dirs: HashMap<PathBuf, (String, String, String)>,
+    /// 各 Agent 的同步状态
+    status: HashMap<String, SyncStatus>,
+}
+```
+
+**公开接口**：
+```rust
+impl SessionWatcher {
+    /// 创建新的监听器，返回 (watcher, event_receiver)
+    pub fn new() -> Result<(Self, mpsc::UnboundedReceiver<FileChangeEvent>), String>
+
+    /// 根据 Agent 配置开始监听 session 目录
+    ///
+    /// 1. 从 config_dir 计算 session 目录（compute_session_dir_from_config）
+    /// 2. 检查目录是否存在（兼容大小写）
+    /// 3. 使用 notify 注册目录监听（非递归，只监听 .jsonl 文件）
+    /// 4. 扫描目录中现有的 .jsonl 文件，发送初始 FileChangeEvent
+    pub fn watch_agent(
+        &mut self,
+        file_id: &str,
+        agent_block_id: &str,
+        config_dir: &str,
+    ) -> Result<(), String>
+
+    /// 停止某个 Agent 关联的 session 监听
+    pub fn unwatch_agent(&mut self, agent_block_id: &str) -> Result<(), String>
+
+    /// 获取某个 Agent 的同步状态
+    pub fn get_status(&self, agent_block_id: &str) -> SyncStatus
+
+    /// 获取所有 Agent 的同步状态
+    pub fn get_all_status(&self) -> HashMap<String, SyncStatus>
+}
+```
+
+**事件过滤规则**：
+- 只关注 `EventKind::Modify` 和 `EventKind::Create` 事件
+- 只处理 `.jsonl` 后缀文件
+- 忽略同名目录（`{uuid}/`）、临时文件（`.tmp`, `.swp`）
+- debounce：100ms 内同一文件的多次变更合并为一次
+
+**实现要点**：
+
+1. **notify 配置**：使用 `RecommendedWatcher`（Windows 下使用 ReadDirectoryChangesW）
+2. **事件转发**：std::sync::mpsc → tokio::sync::mpsc 桥接线程
+3. **首次扫描**：watch 时遍历目录中已有的 `.jsonl` 文件，全部发送 FileChangeEvent
+4. **目录不存在**：状态设为 `Stopped`，不阻塞其他功能
+
+**测试用例**：
+```rust
+#[test] fn test_watch_existing_directory()
+#[test] fn test_watch_nonexistent_directory()
+#[test] fn test_file_change_event_filtering()
+#[test] fn test_unwatch_stops_monitoring()
+#[tokio::test] async fn test_concurrent_watches()
+```
+
+---
+
+### 5.3 F12-01: JSONL 增量解析器 + JSON 转换（4 人时）
+
+**文件**: `src-tauri/src/sync/parser.rs`
+
+**功能描述**：
+增量解析 Claude Code 的 JSONL 文件，**保留原始字段转换为 JSON 格式**。
+
+**核心结构**：
+```rust
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use serde::{Deserialize, Serialize};
+
+/// 单条消息，保留原始 JSONL 字段
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMessage {
+    #[serde(rename = "type")]
+    pub msg_type: String,                    // "user" | "assistant" | "progress" 等
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<serde_json::Value>,  // 完整的 message 对象
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,           // ISO 8601 时间戳
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,             // Claude Code 版本
+    #[serde(rename = "gitBranch", skip_serializing_if = "Option::is_none")]
+    pub git_branch: Option<String>,          // Git 分支
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,     // progress 消息的 data
+}
+
+/// 完整的 Session 数据结构（用于 JSON 序列化）
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionData {
+    pub session_id: String,
+    pub project: String,
+    pub messages: Vec<SessionMessage>,
+}
+
+/// 解析后的 Session 文档（增量数据）
+#[derive(Debug, Clone)]
+pub struct SessionDocument {
+    /// Session ID
+    pub session_id: String,
+    /// 新增的消息列表
+    pub new_messages: Vec<SessionMessage>,
+    /// Session 元信息（从第一条消息提取）
+    pub metadata: SessionMetadata,
+    /// 本次新增的消息数量
+    pub new_message_count: usize,
+}
+
+/// Session 元信息
+#[derive(Debug, Clone, Default)]
+pub struct SessionMetadata {
+    pub model: Option<String>,
+    pub git_branch: Option<String>,
+    pub cwd: Option<String>,
+    pub version: Option<String>,
+    pub started_at: Option<String>,
+}
+
+/// 偏移量跟踪器
+pub struct OffsetTracker {
+    offsets: HashMap<PathBuf, u64>,
+}
+
+/// JSONL 增量解析器
+pub struct SessionParser {
+    tracker: OffsetTracker,
+}
+```
+
+**公开接口**：
+```rust
+impl SessionParser {
+    pub fn new() -> Self
+
+    /// 增量解析 JSONL 文件，返回新增消息列表
+    ///
+    /// # 流程
+    /// 1. 打开文件，seek 到上次偏移量
+    /// 2. 逐行读取 + JSON 解析
+    /// 3. 按 type 分类，转换为 SessionMessage
+    /// 4. 组装为 SessionDocument
+    /// 5. 更新偏移量
+    ///
+    /// # 转换规则
+    /// - user → SessionMessage { role: "user", timestamp, content }
+    /// - assistant (text only) → SessionMessage { role: "assistant", timestamp, content }
+    /// - assistant (thinking/tool_use) → 跳过
+    /// - progress/file-history-snapshot/summary → 跳过
+    pub fn parse_incremental(
+        &mut self,
+        file_path: &Path,
+    ) -> Result<Option<SessionDocument>, String>
+
+    /// 获取/设置偏移量
+    pub fn get_offset(&self, file_path: &Path) -> u64
+    pub fn set_offset(&mut self, file_path: &Path, offset: u64)
+    pub fn reset_offset(&mut self, file_path: &Path)
+}
+
+impl SessionData {
+    pub fn new(session_id: String, project: String) -> Self
+    pub fn to_json(&self) -> String      // 序列化为 JSON 字符串
+    pub fn from_json(json: &str) -> Option<Self>  // 从 JSON 字符串解析
+}
+
+/// 创建初始 SessionData（用于首次写入）
+pub fn create_session_data(
+    metadata: &SessionMetadata,
+    session_id: &str,
+    project_name: &str,
+) -> SessionData
+```
+
+**JSON 转换逻辑**：
+
+```rust
+/// 从 JSONL 对象提取关键字段
+fn jsonl_to_message(json: &serde_json::Value) -> Option<SessionMessage> {
+    // type 字段必需
+    let msg_type = json.get("type")?.as_str()?.to_string();
+
+    // 跳过无用的内部类型
+    if matches!(msg_type.as_str(), "file-history-snapshot" | "summary" | "system" | "result") {
+        return None;
+    }
+
+    Some(SessionMessage {
+        msg_type,
+        message: json.get("message").cloned(),
+        timestamp: json.get("timestamp").and_then(|v| v.as_str()).map(String::from),
+        version: json.get("version").and_then(|v| v.as_str()).map(String::from),
+        git_branch: json.get("gitBranch").and_then(|v| v.as_str()).map(String::from),
+        data: json.get("data").cloned(),
+    })
+}
+```
+
+**保留的消息类型**：
+- `user` — 用户消息（包含完整 message 对象）
+- `assistant` — AI 回复（包含 content 数组：text/thinking/tool_use）
+- `progress` — Agent 子任务进展（包含 data 对象）
+
+**跳过的消息类型**：
+- `file-history-snapshot` — 文件快照
+- `summary` — 会话摘要
+- `system` — 系统消息
+- `result` — 执行结果
+
+**关键设计决策**：
+
+| 决策 | 选择 | 原因 |
+|------|------|------|
+| 存储格式 | **JSON**（保留原始字段） | 保留完整信息，便于前端灵活展示 |
+| message 字段 | **完整保留** | 包含 model、content、usage 等原始数据 |
+| thinking/tool_use | **保留在 message.content 中** | 前端可选择性展示 |
+| progress 消息 | **保留** | 包含 Agent 子任务信息 |
+| 偏移量恢复 | **内存 + Block metadata** | 重启后从 metadata.custom.sync_offset 恢复 |
+
+**测试用例**：
+```rust
+#[test] fn test_parse_user_message()
+#[test] fn test_parse_assistant_message()
+#[test] fn test_assistant_with_tool_use_preserved()
+#[test] fn test_progress_message_preserved()
+#[test] fn test_file_history_snapshot_skipped()
+#[test] fn test_summary_skipped()
+#[test] fn test_session_data_serialization()
+#[test] fn test_missing_type_returns_none()
+#[test] fn test_optional_fields_omitted()
+```
+
+---
+
+### 5.4 F13-01: Session Block 写入器（4 人时）
+
+**文件**: `src-tauri/src/sync/writer.rs`
+
+**功能描述**：
+将解析后的 JSON 文档写入 Elfiee 的 **Markdown Block**（内容为 JSON 字符串），通过 EngineHandle 走完整的事件溯源流程。
+
+**核心结构**：
+```rust
+use crate::engine::actor::EngineHandle;
+use crate::models::Command;
+use crate::sync::parser::{create_session_data, SessionData, SessionDocument, SessionMetadata};
+use std::collections::HashMap;
+
+/// Session Block 写入器 — 写入 JSON 内容
+pub struct SessionWriter {
+    /// session_id → block_id 映射缓存
+    session_blocks: HashMap<String, String>,
+}
+```
+
+**公开接口**：
+```rust
+impl SessionWriter {
+    pub fn new() -> Self
+
+    /// 将 SessionDocument 写入对应的 Markdown Block（JSON 格式）
+    ///
+    /// # 流程
+    /// 1. 查找或创建 session 对应的 Markdown Block
+    /// 2. 读取现有 JSON 内容（如有）→ 解析为 SessionData
+    /// 3. 追加新消息到 SessionData.messages
+    /// 4. 序列化 SessionData → JSON 字符串
+    /// 5. 用 markdown.write 写入
+    /// 6. 更新 metadata（sync_offset, message_count 等）
+    /// 7. 更新 .elf/ session 目录 entries
+    pub async fn write_session(
+        &mut self,
+        handle: &EngineHandle,
+        editor_id: &str,
+        elf_block_id: &str,
+        project_name: &str,
+        config_dir: &str,
+        doc: SessionDocument,
+        source_file: &str,
+        source_offset: u64,
+    ) -> Result<(), String>
+
+    /// 查找或创建 session block
+    async fn create_session_block(
+        &self,
+        handle: &EngineHandle,
+        editor_id: &str,
+        elf_block_id: &str,
+        session_id: &str,
+        project_name: &str,
+        config_dir: &str,
+        source_file: &str,
+        metadata: &SessionMetadata,
+    ) -> Result<String, String>
+
+    /// 恢复已有的 session block 映射和偏移量
+    pub async fn load_existing_sessions(
+        &mut self,
+        handle: &EngineHandle,
+        elf_block_id: &str,
+    ) -> Result<HashMap<String, u64>, String>
+}
+```
+
+**写入流程详解**：
+
+#### Step 1: 创建 Session Block（首次同步）
+
+```rust
+// 1. core.create — 创建 Markdown Block
+let create_cmd = Command::new(
+    editor_id.to_string(),
+    "core.create".to_string(),
+    "".to_string(),
+    json!({
+        "name": format!("session_{}", session_id),
+        "block_type": "markdown",
+        "source": "outline",
+        "metadata": {
+            "description": format!("Claude Code session for {} ({})",
+                project_name, metadata.git_branch.as_deref().unwrap_or("unknown")),
+            "session_id": session_id,
+            "project_name": project_name,
+            "config_dir": config_dir,
+            "source_file": source_file,
+            "sync_offset": 0,
+            "model": metadata.model,
+            "git_branch": metadata.git_branch,
+            "message_count": 0,
+            "last_synced_at": now_utc()
+        }
+    }),
+);
+let events = handle.process_command(create_cmd).await?;
+let block_id = events[0].entity.clone();
+
+// 2. 创建初始 SessionData 并序列化为 JSON
+let mut session_data = create_session_data(&metadata, session_id, project_name);
+session_data.messages.extend(doc.new_messages);
+let initial_content = session_data.to_json();
+
+let write_cmd = Command::new(
+    editor_id.to_string(),
+    "markdown.write".to_string(),
+    block_id.clone(),
+    json!({ "content": initial_content }),
+);
+handle.process_command(write_cmd).await?;
+
+// 3. 更新 .elf/ 的 entries
+// directory.write 添加 session/{project_name}/session_{id}.json 条目
+```
+
+#### Step 2: 追加内容（增量写入）
+
+```rust
+// 1. 获取现有 JSON 内容
+let block = handle.get_block(&block_id).await
+    .ok_or("Session block not found")?;
+let existing_content = block.contents["markdown"].as_str().unwrap_or("");
+
+// 2. 解析为 SessionData，追加新消息
+let mut session_data = SessionData::from_json(existing_content)
+    .unwrap_or_else(|| create_session_data(&metadata, session_id, project_name));
+session_data.messages.extend(doc.new_messages);
+
+// 3. 序列化并写入
+let new_content = session_data.to_json();
+let write_cmd = Command::new(
+    editor_id.to_string(),
+    "markdown.write".to_string(),
+    block_id.clone(),
+    json!({ "content": new_content }),
+);
+handle.process_command(write_cmd).await?;
+
+// 4. 更新 metadata
+let meta_cmd = Command::new(
+    editor_id.to_string(),
+    "core.update_metadata".to_string(),
+    block_id.clone(),
+    json!({
+        "metadata": {
+            "sync_offset": source_offset,
+            "message_count": existing_msg_count + doc.new_message_count,
+            "last_synced_at": now_utc()
+        }
+    }),
+);
+handle.process_command(meta_cmd).await?;
+```
+
+**关键设计决策**：
+
+| 决策 | 选择 | 原因 |
+|------|------|------|
+| Block 类型 | **markdown**（内容为 JSON） | 复用现有 markdown.write 能力 |
+| 写入方式 | **全量 markdown.write** | Event Sourcing 要求每次写入完整内容 |
+| entries 路径 | `session/{project}/session_{id}.json` | `.json` 后缀，体现 JSON 格式 |
+| 偏移量持久化 | **metadata.custom.sync_offset** | 重启后可恢复 |
+
+**Phase 2 限制**：随着 session 增长，单个 Block 内容会越来越大。Phase 3+ 考虑按会话分片。
+
+**测试用例**：
+```rust
+#[tokio::test] async fn test_create_new_session_block()
+#[tokio::test] async fn test_append_to_existing_session()
+#[tokio::test] async fn test_multiple_sessions_separate_blocks()
+#[tokio::test] async fn test_offset_persisted_in_metadata()
+#[tokio::test] async fn test_load_existing_sessions_from_entries()
+#[tokio::test] async fn test_frontmatter_in_initial_content()
+```
+
+---
+
+## 六、模块入口与管理器
+
+### 6.1 sync/mod.rs
+
+**文件**: `src-tauri/src/sync/mod.rs`
+
+```rust
+pub mod session_path;
+pub mod watcher;
+pub mod parser;
+pub mod writer;
+
+#[cfg(test)]
+mod tests;
+
+use crate::engine::actor::EngineHandle;
+use crate::state::AppState;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Session 同步管理器
+///
+/// 协调 Watcher → Parser → Writer 的完整流程。
+/// 通过 Agent Block 的 config_dir 驱动同步。
+pub struct SessionSyncManager {
+    watcher: Arc<Mutex<watcher::SessionWatcher>>,
+    parser: Arc<Mutex<parser::SessionParser>>,
+    writer: Arc<Mutex<writer::SessionWriter>>,
+    sync_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SessionSyncManager {
+    /// 创建新的同步管理器并启动事件处理循环
+    pub fn new(app_state: AppState) -> Result<Self, String>
+
+    /// 为某个 Agent 启动 Session 同步
+    ///
+    /// # 参数
+    /// - `file_id`: .elf 文件 ID
+    /// - `agent_block_id`: Agent Block ID
+    /// - `config_dir`: Agent 的 config_dir（如 "/home/user/repo/.claude"）
+    pub async fn start_sync(
+        &self,
+        file_id: &str,
+        agent_block_id: &str,
+        config_dir: &str,
+    ) -> Result<(), String>
+
+    /// 停止某个 Agent 的 Session 同步
+    pub async fn stop_sync(&self, agent_block_id: &str) -> Result<(), String>
+
+    /// 停止所有同步并清理资源
+    pub async fn shutdown(&mut self)
+
+    /// 获取同步状态
+    pub fn get_status(&self, agent_block_id: &str) -> watcher::SyncStatus
+}
+```
+
+### 6.2 事件处理循环
+
+```rust
+/// 内部事件处理循环
+async fn sync_event_loop(
+    event_rx: mpsc::UnboundedReceiver<FileChangeEvent>,
+    parser: Arc<Mutex<SessionParser>>,
+    writer: Arc<Mutex<SessionWriter>>,
+    app_state: AppState,
+) {
+    while let Some(event) = event_rx.recv().await {
+        // 1. 增量解析 → Markdown
+        let doc = {
+            let mut parser = parser.lock().await;
+            match parser.parse_incremental(&event.path) {
+                Ok(Some(doc)) => doc,
+                Ok(None) => continue,  // 无新内容或全部跳过
+                Err(e) => {
+                    log::error!("Parse error for {:?}: {}", event.path, e);
+                    continue;
+                }
+            }
+        };
+
+        // 2. 获取 Engine 和 Editor
+        let handle = match app_state.engine_manager.get_engine(&event.file_id) {
+            Some(h) => h,
+            None => { log::warn!("Engine not found: {}", event.file_id); continue; }
+        };
+        let editor_id = match app_state.get_active_editor(&event.file_id) {
+            Some(id) => id,
+            None => { log::warn!("No editor: {}", event.file_id); continue; }
+        };
+
+        // 3. 推算 project_name 和 elf_block_id
+        let project_name = session_path::extract_project_name_from_config(&event.config_dir);
+        let elf_block_id = find_elf_block_id(&handle).await;
+
+        let source_offset = {
+            let p = parser.lock().await;
+            p.get_offset(&event.path)
+        };
+
+        // 4. 写入 Markdown Block
+        let mut writer = writer.lock().await;
+        if let Err(e) = writer.write_session(
+            &handle, &editor_id, &elf_block_id,
+            &project_name, doc,
+            &event.path.to_string_lossy(), source_offset,
+        ).await {
+            log::error!("Write error: {}", e);
+        }
+    }
+}
+```
+
+---
+
+## 七、集成点
+
+### 7.1 AppState 扩展
+
+在 `state.rs` 中为 AppState 添加 SessionSyncManager：
+
+```rust
+pub struct AppState {
+    // ... 现有字段 ...
+    /// Session 同步管理器（按需初始化）
+    pub session_sync: Arc<tokio::sync::Mutex<Option<SessionSyncManager>>>,
+}
+```
+
+### 7.2 Agent Enable 时启动同步
+
+在 `commands/agent.rs` 的 `perform_enable_io` 后（或在 Tauri command 层）：
+
+```rust
+// agent.enable 成功后，启动该 Agent 的 Session 同步
+if let Some(sync_manager) = session_sync.lock().await.as_ref() {
+    sync_manager.start_sync(
+        &file_id,
+        &agent_block_id,
+        &agent_contents.config_dir,
+    ).await?;
+}
+```
+
+### 7.3 Agent Disable 时停止同步
+
+```rust
+// agent.disable 时，停止该 Agent 的 Session 同步
+if let Some(sync_manager) = session_sync.lock().await.as_ref() {
+    sync_manager.stop_sync(&agent_block_id).await?;
+}
+```
+
+### 7.4 文件打开时恢复同步
+
+在 `commands/file.rs` 的 `open_file` 末尾：
+
+```rust
+// 扫描所有已启用的 Agent Block，恢复 Session 同步
+for (block_id, block) in all_blocks {
+    if block.block_type == "agent" {
+        let contents: AgentContents = serde_json::from_value(block.contents.clone())?;
+        if contents.status == AgentStatus::Enabled {
+            sync_manager.start_sync(&file_id, &block_id, &contents.config_dir).await?;
+        }
+    }
+}
+```
+
+### 7.5 文件关闭时停止同步
+
+```rust
+// close_file 时停止所有同步
+if let Some(mut sync_manager) = session_sync.lock().await.take() {
+    sync_manager.shutdown().await;
+}
+```
+
+### 7.6 Tauri Command 暴露（可选）
+
+```rust
+// commands/sync.rs (Phase 2 可先不暴露，通过 agent enable/disable 间接控制)
+#[tauri::command]
+#[specta::specta]
+pub async fn get_session_sync_status(
+    file_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<HashMap<String, String>, String>
+```
+
+---
+
+## 八、.elf/ 目录结构更新
+
+Session 同步后，`.elf/` 的 entries 结构变为：
+
+```json
+{
+  "entries": {
+    "agents/": { "id": "dir-xxx", "type": "directory" },
+    "agents/elfiee-client/": { "id": "dir-xxx", "type": "directory" },
+    "session/": { "id": "dir-xxx", "type": "directory" },
+    "session/elfiee/": { "id": "dir-xxx", "type": "directory" },
+    "session/elfiee/session_26b41bcf-ed62-4f38-a04f-cfb4e6fd38b9.json": {
+      "id": "block-uuid-of-markdown-block",
+      "type": "file",
+      "source": "outline",
+      "updated_at": "2026-02-04T..."
+    },
+    "git/": { "id": "dir-xxx", "type": "directory" },
+    "git/hooks/": { "id": "dir-xxx", "type": "directory" }
+  }
+}
+```
+
+**注意**：路径使用 `.json` 后缀，反映 JSON 存储格式。Block 内容为结构化 JSON 字符串。
+
+---
+
+## 九、错误处理与降级策略
+
+| 场景 | 处理方式 |
+|------|----------|
+| Session 目录不存在 | 静默跳过，状态设为 Stopped，不阻塞启动 |
+| 大小写不匹配 | 自动尝试大小写变体查找 |
+| JSONL 行格式错误 | 跳过坏行，log::warn 记录，继续处理后续行 |
+| Engine 不可用 | log::error 记录，等待下次文件变更时重试 |
+| notify watcher 失败 | 降级为定时轮询（每 5s 检查文件修改时间） |
+| markdown.write 失败 | log::error 记录，不更新偏移量（下次重试） |
+| 文件被截断 | 重置偏移量，从头重新解析 |
+| Block 内容过大 | Phase 2 可接受；Phase 3+ 考虑分片 |
+
+---
+
+## 十、开发顺序与验收标准
+
+### 10.1 开发顺序
+
+```
+F10-01 Session 路径计算器 (2h)
+    ↓ 无依赖，可最先开始
+F12-01 JSONL 解析器 + Markdown 转换 (4h)
+    ↓ 依赖路径计算，但逻辑独立
+F11-01 JSONL 文件监听器 (4h)
+    ↓ 依赖路径计算
+F13-01 Session Block 写入器 (4h)
+    ↓ 依赖解析器和 Engine
+模块集成 + 集成测试
+```
+
+**可并行**：F11-01 和 F12-01 可以并行开发。
+
+### 10.2 验收标准
+
+| 编号 | 验收条件 | 验证方式 |
+|------|----------|----------|
+| AC-01 | 路径编码正确（Unix + Windows，含大小写兼容） | 单元测试 |
+| AC-02 | 从 Agent config_dir 正确推算 session 目录 | 单元测试 |
+| AC-03 | 监听到 .jsonl 文件变化并触发事件 | 集成测试 |
+| AC-04 | 增量解析只处理新增行 | 单元测试 |
+| AC-05 | user 消息正确转换为 Markdown | 单元测试 |
+| AC-06 | assistant 消息（text/tool_use）正确转换 | 单元测试 |
+| AC-07 | thinking/progress/snapshot 正确跳过 | 单元测试 |
+| AC-08 | Session Markdown Block 正确创建（含 frontmatter） | 集成测试 |
+| AC-09 | 增量 Markdown 正确追加到已有 Block | 集成测试 |
+| AC-10 | 偏移量在 metadata 中持久化 | 集成测试 |
+| AC-11 | .elf/ entries 正确更新 | 集成测试 |
+| AC-12 | 多 Agent 同时同步不冲突 | 集成测试 |
+| AC-13 | 停止同步后不再写入 | 集成测试 |
+
+### 10.3 文件清单
+
+| 文件 | 类型 | 说明 |
+|------|------|------|
+| `src-tauri/src/sync/mod.rs` | 新建 | 模块入口 + SessionSyncManager |
+| `src-tauri/src/sync/session_path.rs` | 新建 | 路径计算（从 Agent config_dir） |
+| `src-tauri/src/sync/watcher.rs` | 新建 | 文件监听 |
+| `src-tauri/src/sync/parser.rs` | 新建 | JSONL 解析 + Markdown 转换 |
+| `src-tauri/src/sync/writer.rs` | 新建 | Markdown Block 写入 |
+| `src-tauri/src/sync/tests.rs` | 新建 | 测试 |
+| `src-tauri/src/lib.rs` | 修改 | 添加 `pub mod sync;` |
+| `src-tauri/src/state.rs` | 修改 | AppState 添加 session_sync 字段 |
+| `src-tauri/Cargo.toml` | 修改 | 添加 `notify = "7"` 依赖 |
+| `src-tauri/src/commands/agent.rs` | 修改 | enable/disable 时启停同步 |
+| `src-tauri/src/commands/file.rs` | 修改 | open/close 时恢复/停止同步 |
+
+---
+
+## 十一、跨平台注意事项
+
+| 平台 | notify 后端 | 路径编码 | 注意事项 |
+|------|------------|----------|----------|
+| Linux | inotify | `-home-yaosh-projects-elfiee` | 默认 watch 限制 8192 |
+| macOS | FSEvents | `-Users-yaosh-projects-elfiee` | 延迟 ~500ms |
+| Windows | ReadDirectoryChangesW | `d--workspace-zhidaoyuan-elfiee` | **`:` 替换为 `-`，驱动器号可能小写** |
+
+**Windows 路径编码（已验证）**：
+- `D:\workspace\zhidaoyuan\elfiee` → `d--workspace-zhidaoyuan-elfiee`（实际目录名）
+- `:` 移除（不是替换为 `-`），产生连续 `--`
+- 驱动器号可能大写或小写，需兼容两种
+- 同一机器上观察到 `d--` 和 `D--` 共存
+
+---
+
+## 十二、与 v1 文档的主要变更
+
+| 变更点 | v1 | v2 | v3 | 原因 |
+|--------|----|----|-----|------|
+| 路径来源 | Directory Block | Agent Block 的 `config_dir` | (同 v2) | Agent 是 Session 同步的逻辑主体 |
+| 路径编码 | 假设 `:` 替换为 `-` | 验证 `:` 替换为 `-` | (同 v2) | 实际验证结果一致 |
+| 存储格式 | 原始 JSONL → Code Block | Markdown → Markdown Block | **JSON → Markdown Block** | 结构化数据便于程序解析 |
+| JSONL 格式 | 简单 user/assistant | **丰富的 type 体系** | (同 v2) | 实际验证结果 |
+| 触发时机 | open_file | **agent.enable / disable** | (同 v2) | 与 Agent 生命周期绑定 |
+| 文件命名 | `session_{id}.jsonl` | `session_{id}.md` | **`session_{id}.json`** | 反映 JSON 格式 |
+
+---
+
+## 十三、Phase 3+ 演进方向
+
+| 方向 | 说明 |
+|------|------|
+| **分片存储** | session 超过阈值后自动分片为多个 Block |
+| **内容索引** | 对 session 内容建立全文索引，支持搜索 |
+| **摘要生成** | 用 AI 生成 session 摘要，关联到 Session Block |
+| **关联分析** | Session → Task Block 自动关联（基于时间窗口和内容匹配） |
+| **跨模型支持** | 扩展到 Cursor/Copilot 等其他 AI 工具的 session 格式 |
+| **thinking 可选展示** | 用户可配置是否保留 AI 思考过程 |
+| **progress 摘要** | 对 agent 子任务生成摘要而非完全跳过 |
+| **实时同步** | 行级监听，近实时更新 |

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,10 @@ log = "0.4"
 dirs = "5.0"
 axum = "0.8"
 
+# Session sync (file system watching)
+notify = "7"
+notify-debouncer-mini = "0.5"
+
 # MCP (Model Context Protocol)
 rmcp = { version = "0.5", features = ["server", "transport-sse-server"] }
 schemars = "1"

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -357,48 +357,16 @@ pub async fn do_agent_create(
         )
     };
 
-    // 9. Start session sync for this agent
-    {
-        let mut sync_guard = app_state.session_sync.lock().await;
-        if sync_guard.is_none() {
-            match crate::sync::SessionSyncManager::new(app_state.clone()) {
-                Ok(mgr) => {
-                    log::info!("SessionSyncManager created successfully");
-                    *sync_guard = Some(mgr);
-                }
-                Err(e) => {
-                    log::warn!("Failed to create SessionSyncManager: {}", e);
-                }
-            }
-        }
-        if let Some(ref sync_mgr) = *sync_guard {
-            // Restore offsets before starting sync to avoid re-processing
-            if let Some(elf_id) = all_blocks
-                .iter()
-                .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
-                .map(|(id, _)| id.clone())
-            {
-                log::debug!("Restoring offsets for .elf block: {}", elf_id);
-                if let Err(e) = sync_mgr.restore_offsets(&handle, &elf_id).await {
-                    log::warn!("Failed to restore sync offsets: {}", e);
-                }
-            }
-            log::debug!(
-                "Starting session sync: file_id={}, agent_block_id={}, config_dir={}",
-                file_id,
-                agent_block_id,
-                payload.config_dir
-            );
-            if let Err(e) = sync_mgr
-                .start_sync(file_id, &agent_block_id, &payload.config_dir)
-                .await
-            {
-                log::warn!("Failed to start session sync: {}", e);
-            } else {
-                log::info!("Session sync started for agent {}", agent_block_id);
-            }
-        }
-    }
+    // 9. Notify sync observer of new enabled agent
+    let _ =
+        app_state
+            .agent_sync_tx
+            .send(crate::sync::observer::AgentSyncEvent::AgentStateChanged {
+                file_id: file_id.to_string(),
+                agent_block_id: agent_block_id.clone(),
+                new_status: AgentStatus::Enabled,
+                config_dir: payload.config_dir.clone(),
+            });
 
     Ok(AgentCreateResult {
         agent_block_id,
@@ -478,34 +446,16 @@ pub async fn do_agent_enable(
         )
     };
 
-    // Start session sync for this agent
-    {
-        let mut sync_guard = app_state.session_sync.lock().await;
-        if sync_guard.is_none() {
-            match crate::sync::SessionSyncManager::new(app_state.clone()) {
-                Ok(mgr) => *sync_guard = Some(mgr),
-                Err(e) => log::warn!("Failed to create SessionSyncManager: {}", e),
-            }
-        }
-        if let Some(ref sync_mgr) = *sync_guard {
-            // Restore offsets before starting sync to avoid re-processing
-            if let Some(elf_id) = all_blocks
-                .iter()
-                .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
-                .map(|(id, _)| id.clone())
-            {
-                if let Err(e) = sync_mgr.restore_offsets(&handle, &elf_id).await {
-                    log::warn!("Failed to restore sync offsets: {}", e);
-                }
-            }
-            if let Err(e) = sync_mgr
-                .start_sync(file_id, agent_block_id, &contents.config_dir)
-                .await
-            {
-                log::warn!("Failed to start session sync: {}", e);
-            }
-        }
-    }
+    // Notify sync observer of agent enabled
+    let _ =
+        app_state
+            .agent_sync_tx
+            .send(crate::sync::observer::AgentSyncEvent::AgentStateChanged {
+                file_id: file_id.to_string(),
+                agent_block_id: agent_block_id.to_string(),
+                new_status: AgentStatus::Enabled,
+                config_dir: contents.config_dir.clone(),
+            });
 
     Ok(AgentEnableResult {
         agent_block_id: agent_block_id.to_string(),
@@ -563,15 +513,16 @@ pub async fn do_agent_disable(
         .await
         .unwrap_or_else(|e| eprintln!("Warning: Failed to stop agent MCP server: {}", e));
 
-    // Stop session sync for this agent
-    {
-        let sync_guard = app_state.session_sync.lock().await;
-        if let Some(ref sync_mgr) = *sync_guard {
-            if let Err(e) = sync_mgr.stop_sync(agent_block_id).await {
-                log::warn!("Failed to stop session sync: {}", e);
-            }
-        }
-    }
+    // Notify sync observer of agent disabled
+    let _ =
+        app_state
+            .agent_sync_tx
+            .send(crate::sync::observer::AgentSyncEvent::AgentStateChanged {
+                file_id: file_id.to_string(),
+                agent_block_id: agent_block_id.to_string(),
+                new_status: AgentStatus::Disabled,
+                config_dir: contents.config_dir.clone(),
+            });
 
     // Perform I/O: clean up symlink and MCP config
     let warnings = perform_disable_io(&contents.config_dir);
@@ -598,14 +549,15 @@ pub async fn do_agent_disable(
 // Recovery: Restore MCP servers for enabled agents
 // ============================================================================
 
-/// Recover per-agent MCP servers and session sync for all enabled agents in a file.
+/// Recover per-agent MCP servers for all enabled agents in a file.
 ///
 /// Called when a file is opened. For each agent block with status=Enabled:
 /// 1. Allocate a new port (ports don't persist across restarts)
 /// 2. Start per-agent MCP server
 /// 3. Update .mcp.json with the new port
 /// 4. Refresh symlink (idempotent)
-/// 5. Start session sync (JSONL → Markdown)
+///
+/// Session sync is handled separately by the AgentSyncObserver via FileOpened event.
 ///
 /// Returns a list of (agent_name, error_message) for agents that failed to recover.
 /// Successful recoveries are logged to stdout.
@@ -619,29 +571,6 @@ pub async fn recover_agent_servers(app_state: &AppState, file_id: &str) -> Vec<(
 
     let blocks = handle.get_all_blocks().await;
     let elf_block_dir = get_elf_block_dir(&blocks);
-
-    // Initialize SessionSyncManager and restore offsets before starting any agent sync.
-    // This MUST happen before start_sync() to prevent re-processing already-synced content.
-    {
-        let mut sync_guard = app_state.session_sync.lock().await;
-        if sync_guard.is_none() {
-            match crate::sync::SessionSyncManager::new(app_state.clone()) {
-                Ok(mgr) => *sync_guard = Some(mgr),
-                Err(e) => log::warn!("Failed to create SessionSyncManager: {}", e),
-            }
-        }
-        if let Some(ref sync_mgr) = *sync_guard {
-            if let Some(elf_id) = blocks
-                .iter()
-                .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
-                .map(|(id, _)| id.clone())
-            {
-                if let Err(e) = sync_mgr.restore_offsets(&handle, &elf_id).await {
-                    log::warn!("Failed to restore sync offsets: {}", e);
-                }
-            }
-        }
-    }
 
     for block in blocks.values() {
         if block.block_type != "agent" {
@@ -675,23 +604,6 @@ pub async fn recover_agent_servers(app_state: &AppState, file_id: &str) -> Vec<(
                     }
                 }
                 println!("Agent recovery: Restored '{}' on port {}", block.name, port);
-
-                // Start session sync for this agent (manager + offsets already restored above)
-                {
-                    let sync_guard = app_state.session_sync.lock().await;
-                    if let Some(ref sync_mgr) = *sync_guard {
-                        if let Err(e) = sync_mgr
-                            .start_sync(file_id, &block.block_id, &contents.config_dir)
-                            .await
-                        {
-                            log::warn!(
-                                "Agent recovery: Failed to start session sync for '{}': {}",
-                                block.name,
-                                e
-                            );
-                        }
-                    }
-                }
             }
             Err(e) => {
                 eprintln!(
@@ -706,10 +618,11 @@ pub async fn recover_agent_servers(app_state: &AppState, file_id: &str) -> Vec<(
     failures
 }
 
-/// Stop all per-agent MCP servers and session sync for agents in a specific file.
+/// Stop all per-agent MCP servers for agents in a specific file.
 ///
 /// Called when a file is closed. Finds all agent servers belonging to
-/// this file and shuts them down, then shuts down the session sync manager.
+/// this file and shuts them down.
+/// Session sync shutdown is handled by the AgentSyncObserver via FileClosing event.
 pub async fn shutdown_agent_servers(app_state: &AppState, file_id: &str) {
     let handle = match app_state.engine_manager.get_engine(file_id) {
         Some(h) => h,
@@ -727,15 +640,6 @@ pub async fn shutdown_agent_servers(app_state: &AppState, file_id: &str) {
                 block.name, e
             );
         }
-    }
-
-    // Shut down session sync manager
-    {
-        let mut sync_guard = app_state.session_sync.lock().await;
-        if let Some(ref mut sync_mgr) = *sync_guard {
-            sync_mgr.shutdown().await;
-        }
-        *sync_guard = None;
     }
 }
 

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -357,6 +357,49 @@ pub async fn do_agent_create(
         )
     };
 
+    // 9. Start session sync for this agent
+    {
+        let mut sync_guard = app_state.session_sync.lock().await;
+        if sync_guard.is_none() {
+            match crate::sync::SessionSyncManager::new(app_state.clone()) {
+                Ok(mgr) => {
+                    log::info!("SessionSyncManager created successfully");
+                    *sync_guard = Some(mgr);
+                }
+                Err(e) => {
+                    log::warn!("Failed to create SessionSyncManager: {}", e);
+                }
+            }
+        }
+        if let Some(ref sync_mgr) = *sync_guard {
+            // Restore offsets before starting sync to avoid re-processing
+            if let Some(elf_id) = all_blocks
+                .iter()
+                .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
+                .map(|(id, _)| id.clone())
+            {
+                log::debug!("Restoring offsets for .elf block: {}", elf_id);
+                if let Err(e) = sync_mgr.restore_offsets(&handle, &elf_id).await {
+                    log::warn!("Failed to restore sync offsets: {}", e);
+                }
+            }
+            log::debug!(
+                "Starting session sync: file_id={}, agent_block_id={}, config_dir={}",
+                file_id,
+                agent_block_id,
+                payload.config_dir
+            );
+            if let Err(e) = sync_mgr
+                .start_sync(file_id, &agent_block_id, &payload.config_dir)
+                .await
+            {
+                log::warn!("Failed to start session sync: {}", e);
+            } else {
+                log::info!("Session sync started for agent {}", agent_block_id);
+            }
+        }
+    }
+
     Ok(AgentCreateResult {
         agent_block_id,
         status: AgentStatus::Enabled,
@@ -435,6 +478,35 @@ pub async fn do_agent_enable(
         )
     };
 
+    // Start session sync for this agent
+    {
+        let mut sync_guard = app_state.session_sync.lock().await;
+        if sync_guard.is_none() {
+            match crate::sync::SessionSyncManager::new(app_state.clone()) {
+                Ok(mgr) => *sync_guard = Some(mgr),
+                Err(e) => log::warn!("Failed to create SessionSyncManager: {}", e),
+            }
+        }
+        if let Some(ref sync_mgr) = *sync_guard {
+            // Restore offsets before starting sync to avoid re-processing
+            if let Some(elf_id) = all_blocks
+                .iter()
+                .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
+                .map(|(id, _)| id.clone())
+            {
+                if let Err(e) = sync_mgr.restore_offsets(&handle, &elf_id).await {
+                    log::warn!("Failed to restore sync offsets: {}", e);
+                }
+            }
+            if let Err(e) = sync_mgr
+                .start_sync(file_id, agent_block_id, &contents.config_dir)
+                .await
+            {
+                log::warn!("Failed to start session sync: {}", e);
+            }
+        }
+    }
+
     Ok(AgentEnableResult {
         agent_block_id: agent_block_id.to_string(),
         status: AgentStatus::Enabled,
@@ -491,6 +563,16 @@ pub async fn do_agent_disable(
         .await
         .unwrap_or_else(|e| eprintln!("Warning: Failed to stop agent MCP server: {}", e));
 
+    // Stop session sync for this agent
+    {
+        let sync_guard = app_state.session_sync.lock().await;
+        if let Some(ref sync_mgr) = *sync_guard {
+            if let Err(e) = sync_mgr.stop_sync(agent_block_id).await {
+                log::warn!("Failed to stop session sync: {}", e);
+            }
+        }
+    }
+
     // Perform I/O: clean up symlink and MCP config
     let warnings = perform_disable_io(&contents.config_dir);
 
@@ -516,13 +598,14 @@ pub async fn do_agent_disable(
 // Recovery: Restore MCP servers for enabled agents
 // ============================================================================
 
-/// Recover per-agent MCP servers for all enabled agents in a file.
+/// Recover per-agent MCP servers and session sync for all enabled agents in a file.
 ///
 /// Called when a file is opened. For each agent block with status=Enabled:
 /// 1. Allocate a new port (ports don't persist across restarts)
 /// 2. Start per-agent MCP server
 /// 3. Update .mcp.json with the new port
 /// 4. Refresh symlink (idempotent)
+/// 5. Start session sync (JSONL → Markdown)
 ///
 /// Returns a list of (agent_name, error_message) for agents that failed to recover.
 /// Successful recoveries are logged to stdout.
@@ -536,6 +619,29 @@ pub async fn recover_agent_servers(app_state: &AppState, file_id: &str) -> Vec<(
 
     let blocks = handle.get_all_blocks().await;
     let elf_block_dir = get_elf_block_dir(&blocks);
+
+    // Initialize SessionSyncManager and restore offsets before starting any agent sync.
+    // This MUST happen before start_sync() to prevent re-processing already-synced content.
+    {
+        let mut sync_guard = app_state.session_sync.lock().await;
+        if sync_guard.is_none() {
+            match crate::sync::SessionSyncManager::new(app_state.clone()) {
+                Ok(mgr) => *sync_guard = Some(mgr),
+                Err(e) => log::warn!("Failed to create SessionSyncManager: {}", e),
+            }
+        }
+        if let Some(ref sync_mgr) = *sync_guard {
+            if let Some(elf_id) = blocks
+                .iter()
+                .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
+                .map(|(id, _)| id.clone())
+            {
+                if let Err(e) = sync_mgr.restore_offsets(&handle, &elf_id).await {
+                    log::warn!("Failed to restore sync offsets: {}", e);
+                }
+            }
+        }
+    }
 
     for block in blocks.values() {
         if block.block_type != "agent" {
@@ -569,6 +675,23 @@ pub async fn recover_agent_servers(app_state: &AppState, file_id: &str) -> Vec<(
                     }
                 }
                 println!("Agent recovery: Restored '{}' on port {}", block.name, port);
+
+                // Start session sync for this agent (manager + offsets already restored above)
+                {
+                    let sync_guard = app_state.session_sync.lock().await;
+                    if let Some(ref sync_mgr) = *sync_guard {
+                        if let Err(e) = sync_mgr
+                            .start_sync(file_id, &block.block_id, &contents.config_dir)
+                            .await
+                        {
+                            log::warn!(
+                                "Agent recovery: Failed to start session sync for '{}': {}",
+                                block.name,
+                                e
+                            );
+                        }
+                    }
+                }
             }
             Err(e) => {
                 eprintln!(
@@ -583,10 +706,10 @@ pub async fn recover_agent_servers(app_state: &AppState, file_id: &str) -> Vec<(
     failures
 }
 
-/// Stop all per-agent MCP servers for agents in a specific file.
+/// Stop all per-agent MCP servers and session sync for agents in a specific file.
 ///
 /// Called when a file is closed. Finds all agent servers belonging to
-/// this file and shuts them down.
+/// this file and shuts them down, then shuts down the session sync manager.
 pub async fn shutdown_agent_servers(app_state: &AppState, file_id: &str) {
     let handle = match app_state.engine_manager.get_engine(file_id) {
         Some(h) => h,
@@ -604,6 +727,15 @@ pub async fn shutdown_agent_servers(app_state: &AppState, file_id: &str) {
                 block.name, e
             );
         }
+    }
+
+    // Shut down session sync manager
+    {
+        let mut sync_guard = app_state.session_sync.lock().await;
+        if let Some(ref mut sync_mgr) = *sync_guard {
+            sync_mgr.shutdown().await;
+        }
+        *sync_guard = None;
     }
 }
 

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -189,6 +189,13 @@ pub async fn open_file(path: String, state: State<'_, AppState>) -> Result<Strin
         );
     }
 
+    // Notify sync observer that file is opened (triggers session sync recovery)
+    let _ = state
+        .agent_sync_tx
+        .send(crate::sync::observer::AgentSyncEvent::FileOpened {
+            file_id: file_id.clone(),
+        });
+
     Ok(file_id)
 }
 
@@ -234,6 +241,13 @@ pub async fn save_file(file_id: String, state: State<'_, AppState>) -> Result<()
 #[tauri::command]
 #[specta]
 pub async fn close_file(file_id: String, state: State<'_, AppState>) -> Result<(), String> {
+    // Notify sync observer to shut down sync for this file
+    let _ = state
+        .agent_sync_tx
+        .send(crate::sync::observer::AgentSyncEvent::FileClosing {
+            file_id: file_id.clone(),
+        });
+
     // Shutdown per-agent MCP servers before engine shutdown
     crate::commands::agent::shutdown_agent_servers(&state, &file_id).await;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod extensions;
 pub mod mcp;
 pub mod models;
 pub mod state;
+pub mod sync;
 pub mod utils;
 
 use state::AppState;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,10 @@ pub fn run() {
                 }
             });
 
+            // Start AgentSyncObserver (manages session sync lifecycle autonomously)
+            let sync_observer_state = (*app_state).clone();
+            crate::sync::observer::AgentSyncObserver::spawn(sync_observer_state);
+
             // Start MCP Server (independent port, background task)
             let mcp_state = Arc::new((*app_state).clone());
 

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -24,6 +24,20 @@ use serde_json::json;
 use std::future::Future;
 use std::sync::Arc;
 
+/// Truncate a UTF-8 string to a maximum byte length, ensuring the cut
+/// happens at a valid character boundary. Appends "..." if truncated.
+fn truncate_utf8_safe(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    // Find the largest valid char boundary at or before max_bytes
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
+}
+
 /// Elfiee MCP Server
 ///
 /// Provides MCP protocol access to Elfiee's capabilities.
@@ -469,22 +483,14 @@ impl ElfieeMcpServer {
         match block.block_type.as_str() {
             "markdown" => {
                 if let Some(md) = block.contents.get("markdown").and_then(|v| v.as_str()) {
-                    let preview = if md.len() > 200 {
-                        format!("{}...", &md[..200])
-                    } else {
-                        md.to_string()
-                    };
+                    let preview = truncate_utf8_safe(md, 200);
                     summary["content_preview"] = json!(preview);
                     summary["content_length"] = json!(md.len());
                 }
             }
             "code" => {
                 if let Some(code) = block.contents.get("text").and_then(|v| v.as_str()) {
-                    let preview = if code.len() > 200 {
-                        format!("{}...", &code[..200])
-                    } else {
-                        code.to_string()
-                    };
+                    let preview = truncate_utf8_safe(code, 200);
                     summary["content_preview"] = json!(preview);
                     summary["content_length"] = json!(code.len());
                 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,7 +1,7 @@
 use crate::elf::ElfArchive;
 use crate::engine::EngineManager;
 use crate::extensions::terminal::TerminalSession;
-use crate::sync::SessionSyncManager;
+use crate::sync::observer::AgentSyncEvent;
 use dashmap::DashMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -74,9 +74,10 @@ pub struct AppState {
     /// The Tauri app subscribes and emits `state_changed` events to the frontend.
     pub state_changed_tx: broadcast::Sender<String>,
 
-    /// Session sync manager (initialized on-demand per file).
-    /// Manages Claude Code session JSONL → Markdown sync for all agents.
-    pub session_sync: Arc<tokio::sync::Mutex<Option<SessionSyncManager>>>,
+    /// Channel for agent sync events.
+    /// Agent commands and file commands publish here; the AgentSyncObserver subscribes
+    /// and autonomously manages session sync lifecycle.
+    pub agent_sync_tx: broadcast::Sender<AgentSyncEvent>,
 }
 
 impl AppState {
@@ -92,7 +93,7 @@ impl AppState {
             terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
             terminal_output_buffers: Arc::new(DashMap::new()),
             state_changed_tx: broadcast::channel(256).0,
-            session_sync: Arc::new(tokio::sync::Mutex::new(None)),
+            agent_sync_tx: broadcast::channel(64).0,
         }
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,6 +1,7 @@
 use crate::elf::ElfArchive;
 use crate::engine::EngineManager;
 use crate::extensions::terminal::TerminalSession;
+use crate::sync::SessionSyncManager;
 use dashmap::DashMap;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -72,6 +73,10 @@ pub struct AppState {
     /// Both Tauri commands and MCP server send file_id here after successful commands.
     /// The Tauri app subscribes and emits `state_changed` events to the frontend.
     pub state_changed_tx: broadcast::Sender<String>,
+
+    /// Session sync manager (initialized on-demand per file).
+    /// Manages Claude Code session JSONL → Markdown sync for all agents.
+    pub session_sync: Arc<tokio::sync::Mutex<Option<SessionSyncManager>>>,
 }
 
 impl AppState {
@@ -87,6 +92,7 @@ impl AppState {
             terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
             terminal_output_buffers: Arc::new(DashMap::new()),
             state_changed_tx: broadcast::channel(256).0,
+            session_sync: Arc::new(tokio::sync::Mutex::new(None)),
         }
     }
 

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -142,14 +142,26 @@ async fn sync_event_loop(
     while let Some(event) = event_rx.recv().await {
         // Note: Debouncing is handled by notify-debouncer-mini in the watcher (100ms).
 
-        // 1. Parse incrementally
+        // 1. Parse incrementally (offloaded to blocking thread pool to avoid
+        //    blocking the tokio runtime with synchronous file I/O)
         let doc = {
-            let mut parser = parser.lock().await;
-            match parser.parse_incremental(&event.path) {
-                Ok(Some(doc)) => doc,
-                Ok(None) => continue,
-                Err(e) => {
+            let parser_clone = parser.clone();
+            let path = event.path.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let mut parser = parser_clone.blocking_lock();
+                parser.parse_incremental(&path)
+            })
+            .await;
+
+            match result {
+                Ok(Ok(Some(doc))) => doc,
+                Ok(Ok(None)) => continue,
+                Ok(Err(e)) => {
                     log::error!("Parse error for {:?}: {}", event.path, e);
+                    continue;
+                }
+                Err(e) => {
+                    log::error!("Parse task panicked for {:?}: {}", event.path, e);
                     continue;
                 }
             }

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -18,6 +18,7 @@
 //! - `stop_sync()`  — called when an Agent is disabled
 //! - `shutdown()`   — called when a file is closed
 
+pub mod observer;
 pub mod parser;
 pub mod session_path;
 pub mod watcher;

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -1,0 +1,233 @@
+//! Session Sync Module
+//!
+//! Synchronizes Claude Code session data (JSONL files) from external project
+//! directories into Elfiee's `.elf/` storage as readable Markdown Blocks.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! SessionSyncManager (top-level coordinator)
+//! ├── SessionWatcher   — watches session directories via `notify` crate
+//! ├── SessionParser    — incremental JSONL parsing + Markdown conversion
+//! └── SessionWriter    — writes Markdown Blocks via EngineHandle
+//! ```
+//!
+//! ## Lifecycle
+//!
+//! - `start_sync()` — called when an Agent is enabled
+//! - `stop_sync()`  — called when an Agent is disabled
+//! - `shutdown()`   — called when a file is closed
+
+pub mod parser;
+pub mod session_path;
+pub mod watcher;
+pub mod writer;
+
+#[cfg(test)]
+mod tests;
+
+use crate::state::AppState;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex;
+use watcher::{FileChangeEvent, SessionWatcher, SyncStatus};
+
+/// Top-level session sync manager.
+///
+/// Coordinates the Watcher → Parser → Writer pipeline.
+/// One instance per open `.elf` file.
+pub struct SessionSyncManager {
+    watcher: Arc<Mutex<SessionWatcher>>,
+    parser: Arc<Mutex<parser::SessionParser>>,
+    writer: Arc<Mutex<writer::SessionWriter>>,
+    /// Handle to the background sync task
+    sync_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SessionSyncManager {
+    /// Create a new SessionSyncManager and start the background event loop.
+    pub fn new(app_state: AppState) -> Result<Self, String> {
+        let (watcher, event_rx) = SessionWatcher::new()?;
+
+        let parser = Arc::new(Mutex::new(parser::SessionParser::new()));
+        let writer = Arc::new(Mutex::new(writer::SessionWriter::new()));
+        let watcher = Arc::new(Mutex::new(watcher));
+
+        // Start the background event processing loop
+        let parser_clone = parser.clone();
+        let writer_clone = writer.clone();
+        let sync_task = tokio::spawn(sync_event_loop(
+            event_rx,
+            parser_clone,
+            writer_clone,
+            app_state,
+        ));
+
+        Ok(Self {
+            watcher,
+            parser,
+            writer,
+            sync_task: Some(sync_task),
+        })
+    }
+
+    /// Start session sync for an Agent.
+    ///
+    /// Computes the session directory from the Agent's `config_dir`, registers
+    /// the directory with the watcher, and scans existing files.
+    pub async fn start_sync(
+        &self,
+        file_id: &str,
+        agent_block_id: &str,
+        config_dir: &str,
+    ) -> Result<(), String> {
+        let mut watcher = self.watcher.lock().await;
+        watcher.watch_agent(file_id, agent_block_id, config_dir)
+    }
+
+    /// Stop session sync for an Agent.
+    pub async fn stop_sync(&self, agent_block_id: &str) -> Result<(), String> {
+        let mut watcher = self.watcher.lock().await;
+        watcher.unwatch_agent(agent_block_id)
+    }
+
+    /// Get sync status for an Agent.
+    pub async fn get_status(&self, agent_block_id: &str) -> SyncStatus {
+        let watcher = self.watcher.lock().await;
+        watcher.get_status(agent_block_id)
+    }
+
+    /// Restore parser offsets from previously synced blocks.
+    ///
+    /// Called after `start_sync` when re-opening a file to avoid re-processing
+    /// already-synced content.
+    pub async fn restore_offsets(
+        &self,
+        handle: &crate::engine::EngineHandle,
+        elf_block_id: &str,
+    ) -> Result<(), String> {
+        let offset_map = {
+            let mut writer = self.writer.lock().await;
+            writer.load_existing_sessions(handle, elf_block_id).await?
+        };
+
+        let mut parser = self.parser.lock().await;
+        for (source_file, offset) in offset_map {
+            parser.set_offset(std::path::Path::new(&source_file), offset);
+        }
+
+        Ok(())
+    }
+
+    /// Shut down the sync manager and all watchers.
+    pub async fn shutdown(&mut self) {
+        if let Some(task) = self.sync_task.take() {
+            task.abort();
+        }
+        log::info!("Session sync manager shut down");
+    }
+}
+
+/// Background event loop: receives FileChangeEvents and processes them
+/// through the Parser → Writer pipeline.
+async fn sync_event_loop(
+    mut event_rx: mpsc::UnboundedReceiver<FileChangeEvent>,
+    parser: Arc<Mutex<parser::SessionParser>>,
+    writer: Arc<Mutex<writer::SessionWriter>>,
+    app_state: AppState,
+) {
+    log::info!("Session sync event loop started");
+
+    while let Some(event) = event_rx.recv().await {
+        // Note: Debouncing is handled by notify-debouncer-mini in the watcher (100ms).
+
+        // 1. Parse incrementally
+        let doc = {
+            let mut parser = parser.lock().await;
+            match parser.parse_incremental(&event.path) {
+                Ok(Some(doc)) => doc,
+                Ok(None) => continue,
+                Err(e) => {
+                    log::error!("Parse error for {:?}: {}", event.path, e);
+                    continue;
+                }
+            }
+        };
+
+        // 2. Get engine handle
+        let handle = match app_state.engine_manager.get_engine(&event.file_id) {
+            Some(h) => h,
+            None => {
+                log::warn!("Engine not found for file_id: {}", event.file_id);
+                continue;
+            }
+        };
+
+        // 3. Get editor_id (use active editor or fallback to any available editor)
+        let editor_id = match app_state.get_active_editor(&event.file_id) {
+            Some(id) => id,
+            None => {
+                let editors = handle.get_all_editors().await;
+                match editors.keys().next() {
+                    Some(id) => id.clone(),
+                    None => {
+                        log::warn!("No editor available for file_id: {}", event.file_id);
+                        continue;
+                    }
+                }
+            }
+        };
+
+        // 4. Find .elf/ directory block
+        let elf_block_id = match find_elf_block_id(&handle).await {
+            Some(id) => id,
+            None => {
+                log::warn!(
+                    "Cannot find .elf/ directory block for file_id: {}",
+                    event.file_id
+                );
+                continue;
+            }
+        };
+
+        // 5. Derive project name
+        let project_name = session_path::extract_project_name_from_config(&event.config_dir);
+
+        // 6. Get source offset
+        let source_offset = {
+            let p = parser.lock().await;
+            p.get_offset(&event.path)
+        };
+
+        // 7. Write to Markdown Block
+        let mut writer = writer.lock().await;
+        if let Err(e) = writer
+            .write_session(
+                &handle,
+                &editor_id,
+                &elf_block_id,
+                &project_name,
+                &event.config_dir,
+                doc,
+                &event.path.to_string_lossy(),
+                source_offset,
+            )
+            .await
+        {
+            log::error!("Session write error: {}", e);
+        }
+    }
+
+    log::info!("Session sync event loop ended");
+}
+
+/// Find the .elf/ directory block ID from the engine.
+async fn find_elf_block_id(handle: &crate::engine::EngineHandle) -> Option<String> {
+    let blocks = handle.get_all_blocks().await;
+    for (id, block) in &blocks {
+        if block.name == ".elf" && block.block_type == "directory" {
+            return Some(id.clone());
+        }
+    }
+    None
+}

--- a/src-tauri/src/sync/observer.rs
+++ b/src-tauri/src/sync/observer.rs
@@ -1,0 +1,354 @@
+//! Agent Sync Observer
+//!
+//! Autonomous observer that manages session sync lifecycle by subscribing to
+//! agent state change events. This decouples sync logic from agent commands —
+//! agent.rs publishes facts ("agent X is now enabled"), and this observer
+//! reacts by starting or stopping session sync.
+//!
+//! ## Event Flow
+//!
+//! ```text
+//! file.rs::open_file()   → FileOpened   → observer scans enabled agents → start_sync
+//! agent.rs::do_*()       → AgentStateChanged → observer starts/stops sync
+//! file.rs::close_file()  → FileClosing  → observer shuts down sync manager
+//! ```
+
+use crate::extensions::agent::{AgentContents, AgentStatus};
+use crate::state::AppState;
+use crate::sync::SessionSyncManager;
+use std::collections::HashMap;
+use tokio::sync::broadcast;
+
+/// Events that drive the session sync lifecycle.
+///
+/// Published by agent commands and file commands; consumed by `AgentSyncObserver`.
+#[derive(Debug, Clone)]
+pub enum AgentSyncEvent {
+    /// A file was opened — observer should scan for enabled agents and start sync.
+    FileOpened { file_id: String },
+    /// A file is being closed — observer should shut down all sync for this file.
+    FileClosing { file_id: String },
+    /// An agent's status changed — observer should start or stop sync.
+    AgentStateChanged {
+        file_id: String,
+        agent_block_id: String,
+        new_status: AgentStatus,
+        config_dir: String,
+    },
+}
+
+/// Per-file sync state owned by the observer.
+struct FileSyncState {
+    /// The session sync manager for this file.
+    sync_manager: SessionSyncManager,
+    /// Tracks which agents have active sync: agent_block_id → config_dir.
+    active_agents: HashMap<String, String>,
+    /// Whether offsets have been restored (must happen before any start_sync).
+    offsets_restored: bool,
+}
+
+/// Autonomous observer that manages session sync based on agent lifecycle events.
+///
+/// One instance per application, spawned at startup. Owns all `SessionSyncManager`
+/// instances (one per open file with agents).
+pub struct AgentSyncObserver {
+    app_state: AppState,
+    /// Per-file sync state: file_id → FileSyncState.
+    file_states: HashMap<String, FileSyncState>,
+}
+
+impl AgentSyncObserver {
+    fn new(app_state: AppState) -> Self {
+        Self {
+            app_state,
+            file_states: HashMap::new(),
+        }
+    }
+
+    /// Spawn the observer as a background async task.
+    ///
+    /// Uses `tauri::async_runtime::spawn` to ensure compatibility with Tauri's
+    /// setup hook (which may not have a bare Tokio runtime context).
+    /// Subscribes to `app_state.agent_sync_tx` and processes events sequentially.
+    pub fn spawn(app_state: AppState) -> tauri::async_runtime::JoinHandle<()> {
+        let mut rx = app_state.agent_sync_tx.subscribe();
+        let mut observer = Self::new(app_state);
+
+        tauri::async_runtime::spawn(async move {
+            log::info!("AgentSyncObserver started");
+
+            loop {
+                match rx.recv().await {
+                    Ok(event) => observer.handle_event(event).await,
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        log::warn!("AgentSyncObserver lagged by {} events", n);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        log::info!("AgentSyncObserver channel closed, shutting down");
+                        break;
+                    }
+                }
+            }
+
+            observer.shutdown_all().await;
+        })
+    }
+
+    async fn handle_event(&mut self, event: AgentSyncEvent) {
+        match event {
+            AgentSyncEvent::FileOpened { file_id } => {
+                self.handle_file_opened(&file_id).await;
+            }
+            AgentSyncEvent::FileClosing { file_id } => {
+                self.handle_file_closing(&file_id).await;
+            }
+            AgentSyncEvent::AgentStateChanged {
+                file_id,
+                agent_block_id,
+                new_status,
+                config_dir,
+            } => {
+                self.handle_agent_state_changed(&file_id, &agent_block_id, new_status, &config_dir)
+                    .await;
+            }
+        }
+    }
+
+    /// Handle file opened: create sync manager, restore offsets, start sync for enabled agents.
+    async fn handle_file_opened(&mut self, file_id: &str) {
+        let handle = match self.app_state.engine_manager.get_engine(file_id) {
+            Some(h) => h,
+            None => {
+                log::warn!(
+                    "AgentSyncObserver: engine not found for file_id={}",
+                    file_id
+                );
+                return;
+            }
+        };
+
+        // Create SessionSyncManager for this file
+        let sync_mgr = match SessionSyncManager::new(self.app_state.clone()) {
+            Ok(mgr) => {
+                log::info!(
+                    "AgentSyncObserver: SessionSyncManager created for file_id={}",
+                    file_id
+                );
+                mgr
+            }
+            Err(e) => {
+                log::warn!(
+                    "AgentSyncObserver: failed to create SessionSyncManager for {}: {}",
+                    file_id,
+                    e
+                );
+                return;
+            }
+        };
+
+        let mut file_state = FileSyncState {
+            sync_manager: sync_mgr,
+            active_agents: HashMap::new(),
+            offsets_restored: false,
+        };
+
+        let blocks = handle.get_all_blocks().await;
+
+        // Restore offsets ONCE before any start_sync calls
+        if let Some(elf_id) = blocks
+            .iter()
+            .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
+            .map(|(id, _)| id.clone())
+        {
+            if let Err(e) = file_state
+                .sync_manager
+                .restore_offsets(&handle, &elf_id)
+                .await
+            {
+                log::warn!(
+                    "AgentSyncObserver: failed to restore offsets for {}: {}",
+                    file_id,
+                    e
+                );
+            }
+        }
+        file_state.offsets_restored = true;
+
+        // Start sync for all enabled agents
+        for block in blocks.values() {
+            if block.block_type != "agent" {
+                continue;
+            }
+            let contents: AgentContents = match serde_json::from_value(block.contents.clone()) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            if contents.status != AgentStatus::Enabled {
+                continue;
+            }
+            if let Err(e) = file_state
+                .sync_manager
+                .start_sync(file_id, &block.block_id, &contents.config_dir)
+                .await
+            {
+                log::warn!(
+                    "AgentSyncObserver: failed to start sync for agent {}: {}",
+                    block.block_id,
+                    e
+                );
+            } else {
+                file_state
+                    .active_agents
+                    .insert(block.block_id.clone(), contents.config_dir.clone());
+                log::info!(
+                    "AgentSyncObserver: sync started for agent {}",
+                    block.block_id
+                );
+            }
+        }
+
+        self.file_states.insert(file_id.to_string(), file_state);
+    }
+
+    /// Handle file closing: stop all syncs, shutdown sync manager.
+    async fn handle_file_closing(&mut self, file_id: &str) {
+        if let Some(mut file_state) = self.file_states.remove(file_id) {
+            file_state.sync_manager.shutdown().await;
+            log::info!(
+                "AgentSyncObserver: sync manager shut down for file_id={}",
+                file_id
+            );
+        }
+    }
+
+    /// Handle agent state change: start or stop sync.
+    async fn handle_agent_state_changed(
+        &mut self,
+        file_id: &str,
+        agent_block_id: &str,
+        new_status: AgentStatus,
+        config_dir: &str,
+    ) {
+        match new_status {
+            AgentStatus::Enabled => {
+                // Ensure file state exists (lazy init if FileOpened hasn't been received yet)
+                self.ensure_file_state(file_id).await;
+
+                if let Some(file_state) = self.file_states.get_mut(file_id) {
+                    // Restore offsets if not done yet
+                    if !file_state.offsets_restored {
+                        Self::restore_offsets_for_file(&self.app_state, file_id, file_state).await;
+                    }
+
+                    if let Err(e) = file_state
+                        .sync_manager
+                        .start_sync(file_id, agent_block_id, config_dir)
+                        .await
+                    {
+                        log::warn!(
+                            "AgentSyncObserver: failed to start sync for agent {}: {}",
+                            agent_block_id,
+                            e
+                        );
+                    } else {
+                        file_state
+                            .active_agents
+                            .insert(agent_block_id.to_string(), config_dir.to_string());
+                        log::info!(
+                            "AgentSyncObserver: sync started for agent {}",
+                            agent_block_id
+                        );
+                    }
+                }
+            }
+            AgentStatus::Disabled => {
+                if let Some(file_state) = self.file_states.get_mut(file_id) {
+                    if let Err(e) = file_state.sync_manager.stop_sync(agent_block_id).await {
+                        log::warn!(
+                            "AgentSyncObserver: failed to stop sync for agent {}: {}",
+                            agent_block_id,
+                            e
+                        );
+                    }
+                    file_state.active_agents.remove(agent_block_id);
+                    log::info!(
+                        "AgentSyncObserver: sync stopped for agent {}",
+                        agent_block_id
+                    );
+                }
+            }
+        }
+    }
+
+    /// Ensure a FileSyncState exists for the given file_id (lazy initialization).
+    async fn ensure_file_state(&mut self, file_id: &str) {
+        if self.file_states.contains_key(file_id) {
+            return;
+        }
+        match SessionSyncManager::new(self.app_state.clone()) {
+            Ok(mgr) => {
+                log::info!(
+                    "AgentSyncObserver: lazy-initialized SessionSyncManager for file_id={}",
+                    file_id
+                );
+                self.file_states.insert(
+                    file_id.to_string(),
+                    FileSyncState {
+                        sync_manager: mgr,
+                        active_agents: HashMap::new(),
+                        offsets_restored: false,
+                    },
+                );
+            }
+            Err(e) => {
+                log::warn!(
+                    "AgentSyncObserver: failed to create SessionSyncManager for {}: {}",
+                    file_id,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Restore parser offsets from existing session blocks.
+    async fn restore_offsets_for_file(
+        app_state: &AppState,
+        file_id: &str,
+        file_state: &mut FileSyncState,
+    ) {
+        let handle = match app_state.engine_manager.get_engine(file_id) {
+            Some(h) => h,
+            None => return,
+        };
+        let blocks = handle.get_all_blocks().await;
+        if let Some(elf_id) = blocks
+            .iter()
+            .find(|(_, b)| b.name == ".elf" && b.block_type == "directory")
+            .map(|(id, _)| id.clone())
+        {
+            if let Err(e) = file_state
+                .sync_manager
+                .restore_offsets(&handle, &elf_id)
+                .await
+            {
+                log::warn!(
+                    "AgentSyncObserver: failed to restore offsets for {}: {}",
+                    file_id,
+                    e
+                );
+            }
+        }
+        file_state.offsets_restored = true;
+    }
+
+    /// Shutdown all file states (called when the observer loop exits).
+    async fn shutdown_all(&mut self) {
+        for (file_id, mut file_state) in self.file_states.drain() {
+            file_state.sync_manager.shutdown().await;
+            log::info!(
+                "AgentSyncObserver: sync manager shut down for file_id={} (observer shutdown)",
+                file_id
+            );
+        }
+    }
+}

--- a/src-tauri/src/sync/parser.rs
+++ b/src-tauri/src/sync/parser.rs
@@ -1,0 +1,554 @@
+//! JSONL incremental parser + JSON converter
+//!
+//! Parses Claude Code session `.jsonl` files incrementally (using byte offset tracking)
+//! and extracts key fields from each message.
+//!
+//! ## Output Format
+//!
+//! ```json
+//! {
+//!   "session_id": "abc-123",
+//!   "project": "elfiee",
+//!   "messages": [
+//!     {
+//!       "type": "user",
+//!       "message": {"role": "user", "content": "..."},
+//!       "timestamp": "2026-02-03T06:46:50.519Z",
+//!       "version": "2.1.29",
+//!       "gitBranch": "dev"
+//!     },
+//!     {
+//!       "type": "assistant",
+//!       "message": {"model": "claude-opus-4-5", "role": "assistant", "content": [...]},
+//!       "timestamp": "2026-02-03T06:46:55.797Z"
+//!     },
+//!     {
+//!       "type": "progress",
+//!       "data": {"type": "agent_progress", ...},
+//!       "timestamp": "2026-02-03T06:47:09.133Z"
+//!     }
+//!   ]
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+/// A single message in the session, preserving original JSONL fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionMessage {
+    /// Message type: "user", "assistant", "progress", etc.
+    #[serde(rename = "type")]
+    pub msg_type: String,
+
+    /// The message content object (for user/assistant messages)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<serde_json::Value>,
+
+    /// ISO 8601 timestamp
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+
+    /// Claude Code version
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Git branch name
+    #[serde(rename = "gitBranch", skip_serializing_if = "Option::is_none")]
+    pub git_branch: Option<String>,
+
+    /// Progress data (for progress messages)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// The complete session document structure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionData {
+    pub session_id: String,
+    pub project: String,
+    pub messages: Vec<SessionMessage>,
+}
+
+impl SessionData {
+    pub fn new(session_id: String, project: String) -> Self {
+        Self {
+            session_id,
+            project,
+            messages: Vec::new(),
+        }
+    }
+
+    /// Serialize to JSON string.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_default()
+    }
+
+    /// Deserialize from JSON string.
+    pub fn from_json(json: &str) -> Option<Self> {
+        serde_json::from_str(json).ok()
+    }
+}
+
+/// Parsed session document with new messages to append.
+#[derive(Debug, Clone)]
+pub struct SessionDocument {
+    /// Session ID (from sessionId field or filename)
+    pub session_id: String,
+    /// New messages to append
+    pub new_messages: Vec<SessionMessage>,
+    /// Session metadata (extracted from first message)
+    pub metadata: SessionMetadata,
+    /// Number of new messages converted in this parse
+    pub new_message_count: usize,
+}
+
+/// Session metadata extracted from JSONL messages.
+#[derive(Debug, Clone, Default)]
+pub struct SessionMetadata {
+    pub model: Option<String>,
+    pub git_branch: Option<String>,
+    pub cwd: Option<String>,
+    pub version: Option<String>,
+    pub started_at: Option<String>,
+}
+
+/// Tracks byte offsets per file for incremental parsing.
+pub struct OffsetTracker {
+    offsets: HashMap<PathBuf, u64>,
+}
+
+impl OffsetTracker {
+    pub fn new() -> Self {
+        Self {
+            offsets: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, path: &Path) -> u64 {
+        self.offsets.get(path).copied().unwrap_or(0)
+    }
+
+    pub fn set(&mut self, path: &Path, offset: u64) {
+        self.offsets.insert(path.to_path_buf(), offset);
+    }
+
+    pub fn reset(&mut self, path: &Path) {
+        self.offsets.remove(path);
+    }
+}
+
+/// JSONL incremental parser that converts to structured JSON.
+pub struct SessionParser {
+    tracker: OffsetTracker,
+}
+
+impl SessionParser {
+    pub fn new() -> Self {
+        Self {
+            tracker: OffsetTracker::new(),
+        }
+    }
+
+    /// Parse new lines from a JSONL file incrementally.
+    ///
+    /// Returns `Ok(Some(doc))` if new content was found, `Ok(None)` if no
+    /// new meaningful content, `Err` on I/O failure.
+    pub fn parse_incremental(
+        &mut self,
+        file_path: &Path,
+    ) -> Result<Option<SessionDocument>, String> {
+        let file = File::open(file_path)
+            .map_err(|e| format!("Cannot open {}: {}", file_path.display(), e))?;
+
+        let file_len = file
+            .metadata()
+            .map_err(|e| format!("Cannot stat {}: {}", file_path.display(), e))?
+            .len();
+
+        let current_offset = self.tracker.get(file_path);
+
+        // File was truncated — reset and re-parse from start
+        if file_len < current_offset {
+            self.tracker.reset(file_path);
+            return self.parse_incremental(file_path);
+        }
+
+        // No new data
+        if file_len == current_offset {
+            return Ok(None);
+        }
+
+        let mut reader = BufReader::new(file);
+        reader
+            .seek(SeekFrom::Start(current_offset))
+            .map_err(|e| format!("Seek error: {}", e))?;
+
+        let mut new_messages: Vec<SessionMessage> = Vec::new();
+        let mut metadata = SessionMetadata::default();
+        let mut session_id = String::new();
+        let mut new_offset = current_offset;
+
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => break, // EOF
+                Ok(n) => {
+                    new_offset += n as u64;
+                }
+                Err(e) => {
+                    log::warn!("Read error at offset {}: {}", new_offset, e);
+                    break;
+                }
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            let json: serde_json::Value = match serde_json::from_str(trimmed) {
+                Ok(v) => v,
+                Err(e) => {
+                    log::warn!(
+                        "Malformed JSONL line in {}: {} (skipping)",
+                        file_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            // Extract session_id from first message
+            if session_id.is_empty() {
+                if let Some(sid) = json.get("sessionId").and_then(|v| v.as_str()) {
+                    session_id = sid.to_string();
+                }
+            }
+
+            // Extract metadata from early messages
+            update_metadata(&json, &mut metadata);
+
+            // Convert to SessionMessage
+            if let Some(msg) = jsonl_to_message(&json) {
+                new_messages.push(msg);
+            }
+        }
+
+        self.tracker.set(file_path, new_offset);
+
+        if new_messages.is_empty() {
+            return Ok(None);
+        }
+
+        // Fallback: derive session_id from filename if not found in content
+        if session_id.is_empty() {
+            session_id = file_path
+                .file_stem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+        }
+
+        let message_count = new_messages.len();
+
+        Ok(Some(SessionDocument {
+            session_id,
+            new_messages,
+            metadata,
+            new_message_count: message_count,
+        }))
+    }
+
+    /// Get current byte offset for a file.
+    pub fn get_offset(&self, file_path: &Path) -> u64 {
+        self.tracker.get(file_path)
+    }
+
+    /// Set byte offset for a file (used when restoring from persisted metadata).
+    pub fn set_offset(&mut self, file_path: &Path, offset: u64) {
+        self.tracker.set(file_path, offset);
+    }
+
+    /// Reset offset for a file (forces full re-parse on next call).
+    pub fn reset_offset(&mut self, file_path: &Path) {
+        self.tracker.reset(file_path);
+    }
+}
+
+/// Create initial SessionData.
+pub fn create_session_data(
+    _metadata: &SessionMetadata,
+    session_id: &str,
+    project_name: &str,
+) -> SessionData {
+    SessionData {
+        session_id: session_id.to_string(),
+        project: project_name.to_string(),
+        messages: Vec::new(),
+    }
+}
+
+/// Update metadata from a JSONL object (extracts model, branch, cwd, etc.).
+fn update_metadata(json: &serde_json::Value, meta: &mut SessionMetadata) {
+    if meta.model.is_none() {
+        if let Some(model) = json
+            .get("message")
+            .and_then(|m| m.get("model"))
+            .and_then(|v| v.as_str())
+        {
+            meta.model = Some(model.to_string());
+        }
+    }
+    if meta.git_branch.is_none() {
+        if let Some(branch) = json.get("gitBranch").and_then(|v| v.as_str()) {
+            meta.git_branch = Some(branch.to_string());
+        }
+    }
+    if meta.cwd.is_none() {
+        if let Some(cwd) = json.get("cwd").and_then(|v| v.as_str()) {
+            meta.cwd = Some(cwd.to_string());
+        }
+    }
+    if meta.version.is_none() {
+        if let Some(ver) = json.get("version").and_then(|v| v.as_str()) {
+            meta.version = Some(ver.to_string());
+        }
+    }
+    if meta.started_at.is_none() {
+        if let Some(ts) = json.get("timestamp").and_then(|v| v.as_str()) {
+            meta.started_at = Some(ts.to_string());
+        }
+    }
+}
+
+/// Convert a single JSONL object to a SessionMessage.
+///
+/// Extracts fields: type, message, timestamp, version, gitBranch, data
+fn jsonl_to_message(json: &serde_json::Value) -> Option<SessionMessage> {
+    // type is required
+    let msg_type = json.get("type")?.as_str()?.to_string();
+
+    // Skip internal types that are not useful
+    if matches!(
+        msg_type.as_str(),
+        "file-history-snapshot" | "summary" | "system" | "result"
+    ) {
+        return None;
+    }
+
+    Some(SessionMessage {
+        msg_type,
+        message: json.get("message").cloned(),
+        timestamp: json
+            .get("timestamp")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        version: json
+            .get("version")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        git_branch: json
+            .get("gitBranch")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        data: json.get("data").cloned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_user_message() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "user",
+                "message": {"role": "user", "content": "Hello, help me check the code"},
+                "timestamp": "2026-02-03T06:46:50.519Z",
+                "version": "2.1.29",
+                "gitBranch": "dev",
+                "sessionId": "abc123"
+            }"#,
+        )
+        .unwrap();
+
+        let msg = jsonl_to_message(&json).unwrap();
+        assert_eq!(msg.msg_type, "user");
+        assert_eq!(msg.timestamp, Some("2026-02-03T06:46:50.519Z".to_string()));
+        assert_eq!(msg.version, Some("2.1.29".to_string()));
+        assert_eq!(msg.git_branch, Some("dev".to_string()));
+        assert!(msg.message.is_some());
+        let message = msg.message.unwrap();
+        assert_eq!(
+            message["content"].as_str().unwrap(),
+            "Hello, help me check the code"
+        );
+    }
+
+    #[test]
+    fn test_parse_assistant_message() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "assistant",
+                "message": {
+                    "model": "claude-opus-4-5-20251101",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "Let me analyze the code."}
+                    ]
+                },
+                "timestamp": "2026-02-03T06:46:55.797Z"
+            }"#,
+        )
+        .unwrap();
+
+        let msg = jsonl_to_message(&json).unwrap();
+        assert_eq!(msg.msg_type, "assistant");
+        assert_eq!(msg.timestamp, Some("2026-02-03T06:46:55.797Z".to_string()));
+        assert!(msg.message.is_some());
+        let message = msg.message.unwrap();
+        assert_eq!(
+            message["model"].as_str().unwrap(),
+            "claude-opus-4-5-20251101"
+        );
+    }
+
+    #[test]
+    fn test_assistant_with_tool_use_preserved() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "tool_use", "id": "toolu_xxx", "name": "Bash", "input": {"command": "cargo test"}}
+                    ]
+                },
+                "timestamp": "2026-02-03T06:47:00Z"
+            }"#,
+        )
+        .unwrap();
+
+        // Now we preserve assistant messages with tool_use
+        let msg = jsonl_to_message(&json).unwrap();
+        assert_eq!(msg.msg_type, "assistant");
+        assert!(msg.message.is_some());
+    }
+
+    #[test]
+    fn test_progress_message_preserved() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "progress",
+                "data": {"type": "agent_progress", "agentId": "abc123"},
+                "timestamp": "2026-02-03T06:47:09Z"
+            }"#,
+        )
+        .unwrap();
+
+        let msg = jsonl_to_message(&json).unwrap();
+        assert_eq!(msg.msg_type, "progress");
+        assert!(msg.data.is_some());
+        let data = msg.data.unwrap();
+        assert_eq!(data["type"].as_str().unwrap(), "agent_progress");
+        assert_eq!(data["agentId"].as_str().unwrap(), "abc123");
+    }
+
+    #[test]
+    fn test_file_history_snapshot_skipped() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "file-history-snapshot",
+                "files": [],
+                "timestamp": "2026-02-03T06:46:00Z"
+            }"#,
+        )
+        .unwrap();
+
+        assert!(jsonl_to_message(&json).is_none());
+    }
+
+    #[test]
+    fn test_summary_skipped() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "summary",
+                "summary": "Session summary text",
+                "timestamp": "2026-02-03T06:50:00Z"
+            }"#,
+        )
+        .unwrap();
+
+        assert!(jsonl_to_message(&json).is_none());
+    }
+
+    #[test]
+    fn test_session_data_serialization() {
+        let mut data = SessionData::new("abc-123".to_string(), "elfiee".to_string());
+        data.messages.push(SessionMessage {
+            msg_type: "user".to_string(),
+            message: Some(serde_json::json!({"role": "user", "content": "Hello"})),
+            timestamp: Some("2026-02-03T06:46:50.519Z".to_string()),
+            version: Some("2.1.29".to_string()),
+            git_branch: Some("dev".to_string()),
+            data: None,
+        });
+        data.messages.push(SessionMessage {
+            msg_type: "assistant".to_string(),
+            message: Some(serde_json::json!({"role": "assistant", "content": [{"type": "text", "text": "Hi there!"}]})),
+            timestamp: Some("2026-02-03T06:46:55.797Z".to_string()),
+            version: None,
+            git_branch: None,
+            data: None,
+        });
+
+        let json = data.to_json();
+        assert!(json.contains("\"session_id\": \"abc-123\""));
+        assert!(json.contains("\"project\": \"elfiee\""));
+        assert!(json.contains("\"messages\""));
+        assert!(json.contains("\"type\": \"user\""));
+        assert!(json.contains("\"gitBranch\": \"dev\""));
+
+        // Round-trip
+        let parsed = SessionData::from_json(&json).unwrap();
+        assert_eq!(parsed.session_id, "abc-123");
+        assert_eq!(parsed.messages.len(), 2);
+        assert_eq!(parsed.messages[0].msg_type, "user");
+        assert_eq!(parsed.messages[1].msg_type, "assistant");
+    }
+
+    #[test]
+    fn test_missing_type_returns_none() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "message": {"role": "user", "content": "Hello"},
+                "timestamp": "2026-02-03T06:46:50Z"
+            }"#,
+        )
+        .unwrap();
+
+        assert!(jsonl_to_message(&json).is_none());
+    }
+
+    #[test]
+    fn test_optional_fields_omitted() {
+        let msg = SessionMessage {
+            msg_type: "user".to_string(),
+            message: Some(serde_json::json!({"content": "test"})),
+            timestamp: Some("2026-02-03T06:46:50Z".to_string()),
+            version: None,
+            git_branch: None,
+            data: None,
+        };
+
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(!json.contains("version"));
+        assert!(!json.contains("gitBranch"));
+        assert!(!json.contains("data"));
+    }
+}

--- a/src-tauri/src/sync/session_path.rs
+++ b/src-tauri/src/sync/session_path.rs
@@ -1,0 +1,214 @@
+//! Session directory path calculator
+//!
+//! Computes the Claude Code session directory from an Agent Block's `config_dir`.
+//!
+//! ## Path Encoding Rules (verified on actual machines)
+//!
+//! - Windows: `D:\workspace\zhidaoyuan\elfiee` → `D--workspace-zhidaoyuan-elfiee`
+//!   - `\` replaced with `-`
+//!   - `:` replaced with `-` (combined with `\`→`-` produces `D:` → `D-` + `-workspace` = `D--workspace`)
+//!   - Drive letter may be lowercase
+//! - Unix: `/home/yaosh/projects/elfiee` → `-home-yaosh-projects-elfiee`
+//!   - `/` replaced with `-`
+//!   - Leading `/` produces leading `-`
+
+use std::path::{Path, PathBuf};
+
+/// Compute session directory from an Agent's config_dir.
+///
+/// # Flow
+/// 1. Extract parent from config_dir to get the project path
+///    e.g. `D:\workspace\zhidaoyuan\elfiee\.claude` → `D:\workspace\zhidaoyuan\elfiee`
+/// 2. Encode the project path using Claude Code's encoding rules
+/// 3. Combine as `~/.claude/projects/{encoded}/`
+///
+/// # Returns
+/// - `Ok(PathBuf)` — session directory path
+/// - `Err(String)` — config_dir has no parent or home dir unavailable
+pub fn compute_session_dir_from_config(config_dir: &str) -> Result<PathBuf, String> {
+    let config_path = Path::new(config_dir);
+    let project_path = config_path
+        .parent()
+        .ok_or_else(|| format!("config_dir has no parent: {}", config_dir))?;
+
+    compute_session_dir(project_path)
+}
+
+/// Compute session directory from a project path.
+///
+/// Encodes the path and combines with `~/.claude/projects/`.
+pub fn compute_session_dir(project_path: &Path) -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+    let encoded = encode_project_path(project_path);
+
+    Ok(home.join(".claude").join("projects").join(encoded))
+}
+
+/// Encode a project path using Claude Code's encoding rules.
+///
+/// Verified results:
+/// - `D:\workspace\zhidaoyuan\elfiee` → `D--workspace-zhidaoyuan-elfiee`
+/// - `/home/yaosh/projects/elfiee` → `-home-yaosh-projects-elfiee`
+///
+/// Rules (order matters):
+/// 1. Replace `\` with `-`
+/// 2. Replace `/` with `-`
+/// 3. Replace `:` with `-` (NOT removed — produces `D:` → `D-`, combined with `\` → `-` gives `D--`)
+pub fn encode_project_path(path: &Path) -> String {
+    let path_str = path.to_string_lossy().to_string();
+
+    path_str
+        .replace('\\', "-")
+        .replace('/', "-")
+        .replace(':', "-")
+}
+
+/// Extract project name from config_dir.
+///
+/// Takes the parent of config_dir, then returns the last component.
+/// e.g. `D:\workspace\zhidaoyuan\elfiee\.claude` → `elfiee`
+pub fn extract_project_name_from_config(config_dir: &str) -> String {
+    let config_path = Path::new(config_dir);
+    if let Some(project_path) = config_path.parent() {
+        project_path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    } else {
+        "unknown".to_string()
+    }
+}
+
+/// Extract project name from an encoded path string.
+///
+/// Takes the last `-`-separated segment.
+/// e.g. `d--workspace-zhidaoyuan-elfiee` → `elfiee`
+pub fn extract_project_name(encoded_path: &str) -> String {
+    encoded_path
+        .rsplit('-')
+        .next()
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+/// Find session directory, trying case variants on Windows.
+///
+/// Claude Code may use either uppercase or lowercase drive letter.
+/// Returns the first existing directory path, or None.
+pub fn find_session_dir(project_path: &Path) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let encoded = encode_project_path(project_path);
+    let projects_dir = home.join(".claude").join("projects");
+
+    // Try exact encoding first
+    let exact = projects_dir.join(&encoded);
+    if exact.is_dir() {
+        return Some(exact);
+    }
+
+    // On Windows, try toggling the drive letter case
+    #[cfg(windows)]
+    {
+        if let Some(first_char) = encoded.chars().next() {
+            if first_char.is_ascii_alphabetic() {
+                let toggled = if first_char.is_ascii_uppercase() {
+                    let mut s = encoded.clone();
+                    s.replace_range(0..1, &first_char.to_ascii_lowercase().to_string());
+                    s
+                } else {
+                    let mut s = encoded.clone();
+                    s.replace_range(0..1, &first_char.to_ascii_uppercase().to_string());
+                    s
+                };
+
+                let alt = projects_dir.join(&toggled);
+                if alt.is_dir() {
+                    return Some(alt);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Find session directory from config_dir with case-insensitive fallback.
+///
+/// Convenience wrapper combining `compute_session_dir_from_config` with
+/// `find_session_dir` for case-insensitive lookup.
+pub fn find_session_dir_from_config(config_dir: &str) -> Option<PathBuf> {
+    let config_path = Path::new(config_dir);
+    let project_path = config_path.parent()?;
+    find_session_dir(project_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unix_path_encoding() {
+        let path = Path::new("/home/yaosh/projects/elfiee");
+        assert_eq!(encode_project_path(path), "-home-yaosh-projects-elfiee");
+    }
+
+    #[test]
+    fn test_windows_path_encoding() {
+        let path = Path::new("D:\\workspace\\zhidaoyuan\\elfiee");
+        assert_eq!(encode_project_path(path), "D--workspace-zhidaoyuan-elfiee");
+    }
+
+    #[test]
+    fn test_windows_colon_replaced_with_dash() {
+        // `:` is replaced with `-`, combined with `\` also becoming `-`:
+        // D:\workspace → D + - (from :) + - (from \) + workspace = D--workspace
+        let path = Path::new("D:\\workspace");
+        assert_eq!(encode_project_path(path), "D--workspace");
+        // Should NOT produce triple --- (would happen if `:` produced two dashes)
+        let full = encode_project_path(Path::new("D:\\workspace\\elfiee"));
+        assert!(!full.contains("---"));
+    }
+
+    #[test]
+    fn test_extract_project_name() {
+        assert_eq!(
+            extract_project_name("d--workspace-zhidaoyuan-elfiee"),
+            "elfiee"
+        );
+    }
+
+    #[test]
+    fn test_extract_project_name_unix() {
+        assert_eq!(
+            extract_project_name("-home-yaosh-projects-elfiee"),
+            "elfiee"
+        );
+    }
+
+    #[test]
+    fn test_extract_project_name_from_config_windows() {
+        assert_eq!(
+            extract_project_name_from_config("D:\\workspace\\zhidaoyuan\\elfiee\\.claude"),
+            "elfiee"
+        );
+    }
+
+    #[test]
+    fn test_extract_project_name_from_config_unix() {
+        assert_eq!(
+            extract_project_name_from_config("/home/yaosh/projects/elfiee/.claude"),
+            "elfiee"
+        );
+    }
+
+    #[test]
+    fn test_config_dir_to_session_dir() {
+        let result = compute_session_dir_from_config("D:\\workspace\\zhidaoyuan\\elfiee\\.claude");
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        let path_str = path.to_string_lossy().to_string();
+        assert!(path_str.contains(".claude"));
+        assert!(path_str.contains("projects"));
+        assert!(path_str.contains("D--workspace-zhidaoyuan-elfiee"));
+    }
+}

--- a/src-tauri/src/sync/session_path.rs
+++ b/src-tauri/src/sync/session_path.rs
@@ -186,6 +186,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn test_extract_project_name_from_config_windows() {
         assert_eq!(
             extract_project_name_from_config("D:\\workspace\\zhidaoyuan\\elfiee\\.claude"),
@@ -202,6 +203,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(windows)]
     fn test_config_dir_to_session_dir() {
         let result = compute_session_dir_from_config("D:\\workspace\\zhidaoyuan\\elfiee\\.claude");
         assert!(result.is_ok());

--- a/src-tauri/src/sync/session_path.rs
+++ b/src-tauri/src/sync/session_path.rs
@@ -195,6 +195,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn test_extract_project_name_from_config_unix() {
         assert_eq!(
             extract_project_name_from_config("/home/yaosh/projects/elfiee/.claude"),
@@ -212,5 +213,17 @@ mod tests {
         assert!(path_str.contains(".claude"));
         assert!(path_str.contains("projects"));
         assert!(path_str.contains("D--workspace-zhidaoyuan-elfiee"));
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_config_dir_to_session_dir_unix() {
+        let result = compute_session_dir_from_config("/home/yaosh/projects/elfiee/.claude");
+        assert!(result.is_ok());
+        let path = result.unwrap();
+        let path_str = path.to_string_lossy().to_string();
+        assert!(path_str.contains(".claude"));
+        assert!(path_str.contains("projects"));
+        assert!(path_str.contains("-home-yaosh-projects-elfiee"));
     }
 }

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -195,9 +195,7 @@ fn test_encode_nested_project_path() {
 #[test]
 #[cfg(not(windows))]
 fn test_encode_nested_project_path_unix() {
-    let encoded = encode_project_path(Path::new(
-        "/home/yaosh/projects/elfiee-project/elfiee",
-    ));
+    let encoded = encode_project_path(Path::new("/home/yaosh/projects/elfiee-project/elfiee"));
     assert_eq!(encoded, "-home-yaosh-projects-elfiee-project-elfiee");
 }
 
@@ -216,9 +214,7 @@ fn test_extract_project_name_from_complex_path() {
 #[cfg(not(windows))]
 fn test_extract_project_name_from_complex_path_unix() {
     assert_eq!(
-        extract_project_name_from_config(
-            "/home/yaosh/projects/frontend-component-library/.cursor"
-        ),
+        extract_project_name_from_config("/home/yaosh/projects/frontend-component-library/.cursor"),
         "frontend-component-library"
     );
 }

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -184,6 +184,7 @@ fn test_encode_temp_path() {
 }
 
 #[test]
+#[cfg(windows)]
 fn test_encode_nested_project_path() {
     let encoded = encode_project_path(Path::new(
         "D:\\workspace\\zhidaoyuan\\elfiee-peoject\\elfiee",
@@ -192,6 +193,7 @@ fn test_encode_nested_project_path() {
 }
 
 #[test]
+#[cfg(windows)]
 fn test_extract_project_name_from_complex_path() {
     assert_eq!(
         extract_project_name_from_config(

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -193,11 +193,31 @@ fn test_encode_nested_project_path() {
 }
 
 #[test]
+#[cfg(not(windows))]
+fn test_encode_nested_project_path_unix() {
+    let encoded = encode_project_path(Path::new(
+        "/home/yaosh/projects/elfiee-project/elfiee",
+    ));
+    assert_eq!(encoded, "-home-yaosh-projects-elfiee-project-elfiee");
+}
+
+#[test]
 #[cfg(windows)]
 fn test_extract_project_name_from_complex_path() {
     assert_eq!(
         extract_project_name_from_config(
             "D:\\workspace\\zhidaoyuan\\frontend-component-library\\.cursor"
+        ),
+        "frontend-component-library"
+    );
+}
+
+#[test]
+#[cfg(not(windows))]
+fn test_extract_project_name_from_complex_path_unix() {
+    assert_eq!(
+        extract_project_name_from_config(
+            "/home/yaosh/projects/frontend-component-library/.cursor"
         ),
         "frontend-component-library"
     );

--- a/src-tauri/src/sync/tests.rs
+++ b/src-tauri/src/sync/tests.rs
@@ -1,0 +1,384 @@
+//! Tests for the session sync module.
+//!
+//! Unit tests for session_path and parser are co-located in their respective files.
+//! This file contains integration-level tests.
+
+use super::parser::*;
+use super::session_path::*;
+use std::io::Write;
+use std::path::Path;
+use tempfile::TempDir;
+
+// ============================================================================
+// Parser Integration Tests
+// ============================================================================
+
+#[test]
+fn test_incremental_parse_only_new_lines() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("test-session.jsonl");
+
+    // Write initial content
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Hello"}},"timestamp":"2026-02-03T06:00:00Z","sessionId":"test-1"}}"#
+        )
+        .unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+
+    // First parse
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    assert_eq!(doc.session_id, "test-1");
+    assert_eq!(doc.new_message_count, 1);
+    assert_eq!(doc.new_messages.len(), 1);
+    assert_eq!(doc.new_messages[0].msg_type, "user");
+    let msg = doc.new_messages[0].message.as_ref().unwrap();
+    assert!(msg["content"].as_str().unwrap().contains("Hello"));
+
+    // Parse again without changes → should return None
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_none());
+
+    // Append new content
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&file_path)
+            .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"Hi there!"}}]}},"timestamp":"2026-02-03T06:01:00Z"}}"#
+        )
+        .unwrap();
+    }
+
+    // Second parse — should only get the new line
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    assert_eq!(doc.new_message_count, 1);
+    assert_eq!(doc.new_messages.len(), 1);
+    assert_eq!(doc.new_messages[0].msg_type, "assistant");
+    let msg = doc.new_messages[0].message.as_ref().unwrap();
+    let content = &msg["content"][0]["text"];
+    assert!(content.as_str().unwrap().contains("Hi there!"));
+}
+
+#[test]
+fn test_malformed_line_skipped() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("malformed.jsonl");
+
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(f, "this is not json").unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Valid"}},"timestamp":"2026-02-03T06:00:00Z","sessionId":"test-2"}}"#
+        )
+        .unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    assert_eq!(doc.new_message_count, 1);
+    assert_eq!(doc.new_messages.len(), 1);
+    let msg = doc.new_messages[0].message.as_ref().unwrap();
+    assert!(msg["content"].as_str().unwrap().contains("Valid"));
+}
+
+#[test]
+fn test_file_truncation_resets_offset() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("truncated.jsonl");
+
+    // Write long content
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        for i in 0..10 {
+            writeln!(
+                f,
+                r#"{{"type":"user","message":{{"role":"user","content":"Message {}"}},"timestamp":"2026-02-03T06:0{}:00Z","sessionId":"test-3"}}"#,
+                i, i
+            )
+            .unwrap();
+        }
+    }
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().new_message_count, 10);
+
+    // Truncate file (shorter than previous offset)
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Fresh start"}},"timestamp":"2026-02-03T07:00:00Z","sessionId":"test-3"}}"#
+        )
+        .unwrap();
+    }
+
+    // Should detect truncation and re-parse from start
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    assert_eq!(doc.new_message_count, 1);
+    assert_eq!(doc.new_messages.len(), 1);
+    let msg = doc.new_messages[0].message.as_ref().unwrap();
+    assert!(msg["content"].as_str().unwrap().contains("Fresh start"));
+}
+
+#[test]
+fn test_empty_file_returns_none() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("empty.jsonl");
+    std::fs::File::create(&file_path).unwrap();
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_session_id_from_filename_fallback() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("abc-123-def.jsonl");
+
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        // Write a message without sessionId
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Test"}},"timestamp":"2026-02-03T06:00:00Z"}}"#
+        )
+        .unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    assert_eq!(result.unwrap().session_id, "abc-123-def");
+}
+
+// ============================================================================
+// Path Encoding Tests (additional)
+// ============================================================================
+
+#[test]
+fn test_encode_temp_path() {
+    // Temp paths like "C:\Users\Lenovo\AppData\Local\Temp\tmp6mKgVe"
+    let encoded = encode_project_path(Path::new(
+        "C:\\Users\\Lenovo\\AppData\\Local\\Temp\\tmp6mKgVe",
+    ));
+    assert_eq!(encoded, "C--Users-Lenovo-AppData-Local-Temp-tmp6mKgVe");
+}
+
+#[test]
+fn test_encode_nested_project_path() {
+    let encoded = encode_project_path(Path::new(
+        "D:\\workspace\\zhidaoyuan\\elfiee-peoject\\elfiee",
+    ));
+    assert_eq!(encoded, "D--workspace-zhidaoyuan-elfiee-peoject-elfiee");
+}
+
+#[test]
+fn test_extract_project_name_from_complex_path() {
+    assert_eq!(
+        extract_project_name_from_config(
+            "D:\\workspace\\zhidaoyuan\\frontend-component-library\\.cursor"
+        ),
+        "frontend-component-library"
+    );
+}
+
+// ============================================================================
+// Additional Tests per Requirements Document
+// ============================================================================
+
+#[test]
+fn test_metadata_extraction() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("metadata-test.jsonl");
+
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        // User message with metadata
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Hello"}},"timestamp":"2026-02-03T06:00:00Z","sessionId":"meta-test","version":"2.1.29","gitBranch":"dev","cwd":"D:\\workspace\\elfiee"}}"#
+        ).unwrap();
+        // Assistant message with model info
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"model":"claude-opus-4-5-20251101","role":"assistant","content":[{{"type":"text","text":"Hi!"}}]}},"timestamp":"2026-02-03T06:01:00Z"}}"#
+        ).unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+
+    // Check metadata was extracted
+    assert_eq!(doc.metadata.version, Some("2.1.29".to_string()));
+    assert_eq!(doc.metadata.git_branch, Some("dev".to_string()));
+    assert_eq!(doc.metadata.cwd, Some("D:\\workspace\\elfiee".to_string()));
+    assert_eq!(
+        doc.metadata.model,
+        Some("claude-opus-4-5-20251101".to_string())
+    );
+    assert_eq!(
+        doc.metadata.started_at,
+        Some("2026-02-03T06:00:00Z".to_string())
+    );
+}
+
+#[test]
+fn test_session_data_round_trip() {
+    // Create session data with messages
+    let mut data = SessionData::new("test-session-123".to_string(), "my-project".to_string());
+    data.messages.push(SessionMessage {
+        msg_type: "user".to_string(),
+        message: Some(serde_json::json!({"role": "user", "content": "Hello world"})),
+        timestamp: Some("2026-02-03T06:00:00Z".to_string()),
+        version: Some("2.1.29".to_string()),
+        git_branch: Some("main".to_string()),
+        data: None,
+    });
+    data.messages.push(SessionMessage {
+        msg_type: "progress".to_string(),
+        message: None,
+        timestamp: Some("2026-02-03T06:01:00Z".to_string()),
+        version: None,
+        git_branch: None,
+        data: Some(serde_json::json!({"type": "agent_progress", "agentId": "xyz"})),
+    });
+
+    // Serialize to JSON
+    let json = data.to_json();
+
+    // Deserialize back
+    let parsed = SessionData::from_json(&json).unwrap();
+
+    // Verify round-trip
+    assert_eq!(parsed.session_id, "test-session-123");
+    assert_eq!(parsed.project, "my-project");
+    assert_eq!(parsed.messages.len(), 2);
+    assert_eq!(parsed.messages[0].msg_type, "user");
+    assert_eq!(parsed.messages[0].git_branch, Some("main".to_string()));
+    assert_eq!(parsed.messages[1].msg_type, "progress");
+    assert!(parsed.messages[1].data.is_some());
+}
+
+#[test]
+fn test_offset_persistence_and_restore() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("offset-test.jsonl");
+
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Line 1"}},"timestamp":"2026-02-03T06:00:00Z","sessionId":"offset-test"}}"#
+        ).unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+
+    // Parse first line
+    let _ = parser.parse_incremental(&file_path).unwrap();
+
+    // Get offset
+    let offset = parser.get_offset(&file_path);
+    assert!(offset > 0);
+
+    // Simulate restart: new parser with restored offset
+    let mut parser2 = SessionParser::new();
+    parser2.set_offset(&file_path, offset);
+
+    // Should return None since no new content
+    let result = parser2.parse_incremental(&file_path).unwrap();
+    assert!(result.is_none());
+
+    // Append new content
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&file_path)
+            .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Line 2"}},"timestamp":"2026-02-03T06:01:00Z"}}"#
+        ).unwrap();
+    }
+
+    // Now should get the new line
+    let result = parser2.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    assert_eq!(doc.new_message_count, 1);
+    let msg = doc.new_messages[0].message.as_ref().unwrap();
+    assert!(msg["content"].as_str().unwrap().contains("Line 2"));
+}
+
+#[test]
+fn test_system_message_skipped() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("system-skip.jsonl");
+
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"system","content":"System initialized","timestamp":"2026-02-03T06:00:00Z","sessionId":"sys-test"}}"#
+        ).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","message":{{"role":"user","content":"Hello"}},"timestamp":"2026-02-03T06:01:00Z"}}"#
+        ).unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    // Only the user message should be parsed
+    assert_eq!(doc.new_message_count, 1);
+    assert_eq!(doc.new_messages[0].msg_type, "user");
+}
+
+#[test]
+fn test_result_message_skipped() {
+    let dir = TempDir::new().unwrap();
+    let file_path = dir.path().join("result-skip.jsonl");
+
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"result","result":{{"success":true}},"timestamp":"2026-02-03T06:00:00Z","sessionId":"result-test"}}"#
+        ).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"Done"}}]}},"timestamp":"2026-02-03T06:01:00Z"}}"#
+        ).unwrap();
+    }
+
+    let mut parser = SessionParser::new();
+    let result = parser.parse_incremental(&file_path).unwrap();
+    assert!(result.is_some());
+    let doc = result.unwrap();
+    // Only the assistant message should be parsed
+    assert_eq!(doc.new_message_count, 1);
+    assert_eq!(doc.new_messages[0].msg_type, "assistant");
+}

--- a/src-tauri/src/sync/watcher.rs
+++ b/src-tauri/src/sync/watcher.rs
@@ -93,6 +93,8 @@ pub struct SessionWatcher {
     watching_parent: Arc<StdMutex<bool>>,
     /// Per-agent sync status
     status_map: HashMap<String, SyncStatus>,
+    /// Handle to the bridge thread for cleanup on drop
+    bridge_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl SessionWatcher {
@@ -127,7 +129,7 @@ impl SessionWatcher {
         let watched_dirs_bridge = watched_dirs.clone();
         let pending_agents_bridge = pending_agents.clone();
 
-        std::thread::Builder::new()
+        let bridge_thread = std::thread::Builder::new()
             .name("session-sync-bridge".into())
             .spawn(move || {
                 while let Ok(events) = notify_rx.recv() {
@@ -146,11 +148,15 @@ impl SessionWatcher {
 
                             pending.retain(|agent| {
                                 // Check if the created directory matches expected session dir
-                                // Also check case-insensitive match for Windows
-                                let matches = path == &agent.expected_session_dir
-                                    || path.to_string_lossy().eq_ignore_ascii_case(
+                                // Windows: case-insensitive (filesystem is case-insensitive)
+                                // Unix: exact match (filesystem is case-sensitive)
+                                let matches = if cfg!(windows) {
+                                    path.to_string_lossy().eq_ignore_ascii_case(
                                         &agent.expected_session_dir.to_string_lossy(),
-                                    );
+                                    )
+                                } else {
+                                    path == &agent.expected_session_dir
+                                };
 
                                 if matches {
                                     log::info!(
@@ -242,6 +248,7 @@ impl SessionWatcher {
                 pending_agents,
                 watching_parent,
                 status_map: HashMap::new(),
+                bridge_thread: Some(bridge_thread),
             },
             event_rx,
         ))
@@ -489,5 +496,21 @@ impl SessionWatcher {
         }
 
         result
+    }
+}
+
+impl Drop for SessionWatcher {
+    fn drop(&mut self) {
+        // The bridge thread will exit naturally when `watcher` is dropped,
+        // because the Debouncer will drop its callback which drops notify_tx,
+        // causing notify_rx.recv() to return Err and exit the loop.
+        //
+        // We join here to ensure the thread has fully terminated before
+        // the SessionWatcher is considered dropped.
+        if let Some(handle) = self.bridge_thread.take() {
+            // Give the thread a moment to exit after watcher is dropped
+            // (watcher is dropped before bridge_thread due to field order)
+            let _ = handle.join();
+        }
     }
 }

--- a/src-tauri/src/sync/watcher.rs
+++ b/src-tauri/src/sync/watcher.rs
@@ -1,0 +1,493 @@
+//! JSONL file system watcher
+//!
+//! Uses the `notify` crate with `notify-debouncer-mini` to watch Claude Code
+//! session directories for new/modified `.jsonl` files and forwards change
+//! events to the sync pipeline.
+//!
+//! ## Debouncing
+//!
+//! File changes are debounced at 100ms to coalesce rapid writes from Claude Code.
+//! This is handled in the watcher itself using `notify-debouncer-mini`.
+
+use crate::sync::session_path;
+use notify::RecursiveMode;
+use notify_debouncer_mini::{new_debouncer, DebouncedEvent, DebouncedEventKind, Debouncer};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::mpsc as std_mpsc;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+/// Session sync status for an Agent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Type)]
+pub enum SyncStatus {
+    /// Actively watching the session directory
+    Watching,
+    /// Waiting for session directory to be created (watching parent directory)
+    WaitingForDirectory,
+    /// Stopped (manually stopped)
+    Stopped,
+    /// Error state
+    Error(String),
+}
+
+/// A file change event forwarded from the watcher to the parser/writer pipeline.
+#[derive(Debug)]
+pub struct FileChangeEvent {
+    /// Path to the changed `.jsonl` file
+    pub path: PathBuf,
+    /// Agent Block ID that owns this session directory
+    pub agent_block_id: String,
+    /// The `.elf` file ID
+    pub file_id: String,
+    /// Agent's config_dir (used to derive project name)
+    pub config_dir: String,
+}
+
+/// Metadata for a watched directory (maps session_dir → agent info).
+///
+/// Shared between the watcher and the notify bridge thread via Arc<Mutex>.
+pub(crate) struct WatchEntry {
+    pub file_id: String,
+    pub agent_block_id: String,
+    pub config_dir: String,
+}
+
+/// Pending agent waiting for its session directory to be created.
+///
+/// When the session directory doesn't exist yet, we watch the parent directory
+/// (`~/.claude/projects/`) and wait for the target subdirectory to appear.
+#[derive(Clone)]
+pub(crate) struct PendingAgent {
+    pub file_id: String,
+    pub agent_block_id: String,
+    pub config_dir: String,
+    /// The expected session directory path (may not exist yet)
+    pub expected_session_dir: PathBuf,
+}
+
+/// Session file watcher using the `notify` crate with debouncing.
+///
+/// Watches one or more session directories (one per Agent) and sends
+/// `FileChangeEvent`s to the sync pipeline via a tokio mpsc channel.
+/// File changes are debounced at 100ms to coalesce rapid writes.
+///
+/// ## Directory Creation Handling
+///
+/// When the session directory doesn't exist yet (user hasn't used Claude Code
+/// in that project), we watch the parent directory (`~/.claude/projects/`)
+/// and automatically start watching the subdirectory when it's created.
+pub struct SessionWatcher {
+    /// The underlying debounced watcher (100ms debounce)
+    watcher: Debouncer<notify::RecommendedWatcher>,
+    /// Event sender for the sync pipeline
+    event_tx: mpsc::UnboundedSender<FileChangeEvent>,
+    /// Shared watched directories map (used by both watcher methods and bridge thread)
+    watched_dirs: Arc<StdMutex<HashMap<PathBuf, WatchEntry>>>,
+    /// Pending agents waiting for their session directories to be created
+    pending_agents: Arc<StdMutex<Vec<PendingAgent>>>,
+    /// Whether we're watching the parent directory (~/.claude/projects/)
+    watching_parent: Arc<StdMutex<bool>>,
+    /// Per-agent sync status
+    status_map: HashMap<String, SyncStatus>,
+}
+
+impl SessionWatcher {
+    /// Create a new SessionWatcher with 100ms debouncing.
+    ///
+    /// Returns `(watcher, event_receiver)` — the receiver should be consumed
+    /// by the sync event loop.
+    pub fn new() -> Result<(Self, mpsc::UnboundedReceiver<FileChangeEvent>), String> {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (notify_tx, notify_rx) = std_mpsc::channel::<Vec<DebouncedEvent>>();
+
+        // Shared state between watcher methods and the bridge thread
+        let watched_dirs: Arc<StdMutex<HashMap<PathBuf, WatchEntry>>> =
+            Arc::new(StdMutex::new(HashMap::new()));
+        let pending_agents: Arc<StdMutex<Vec<PendingAgent>>> = Arc::new(StdMutex::new(Vec::new()));
+        let watching_parent: Arc<StdMutex<bool>> = Arc::new(StdMutex::new(false));
+
+        // Create debounced watcher with 100ms debounce time
+        let watcher = new_debouncer(
+            Duration::from_millis(100),
+            move |res: Result<Vec<DebouncedEvent>, notify::Error>| {
+                if let Ok(events) = res {
+                    let _ = notify_tx.send(events);
+                }
+            },
+        )
+        .map_err(|e| format!("Failed to create debounced file watcher: {}", e))?;
+
+        // Bridge thread: std_mpsc → tokio mpsc
+        // The notify callback runs on an OS thread, so we bridge to the async world.
+        let event_tx_bridge = event_tx.clone();
+        let watched_dirs_bridge = watched_dirs.clone();
+        let pending_agents_bridge = pending_agents.clone();
+
+        std::thread::Builder::new()
+            .name("session-sync-bridge".into())
+            .spawn(move || {
+                while let Ok(events) = notify_rx.recv() {
+                    for event in events {
+                        // Only process Any events (debouncer merges Create/Modify/etc.)
+                        if !matches!(event.kind, DebouncedEventKind::Any) {
+                            continue;
+                        }
+
+                        let path = &event.path;
+
+                        // Check if this is a new directory that matches a pending agent
+                        if path.is_dir() {
+                            let mut pending = pending_agents_bridge.lock().unwrap();
+                            let mut to_activate: Vec<PendingAgent> = Vec::new();
+
+                            pending.retain(|agent| {
+                                // Check if the created directory matches expected session dir
+                                // Also check case-insensitive match for Windows
+                                let matches = path == &agent.expected_session_dir
+                                    || path.to_string_lossy().eq_ignore_ascii_case(
+                                        &agent.expected_session_dir.to_string_lossy(),
+                                    );
+
+                                if matches {
+                                    log::info!(
+                                        "Session directory created: {} (agent {})",
+                                        path.display(),
+                                        agent.agent_block_id
+                                    );
+                                    to_activate.push(agent.clone());
+                                    false // Remove from pending
+                                } else {
+                                    true // Keep in pending
+                                }
+                            });
+
+                            // For activated agents, add to watched_dirs and scan for existing files
+                            for agent in to_activate {
+                                let mut dirs = watched_dirs_bridge.lock().unwrap();
+                                dirs.insert(
+                                    path.clone(),
+                                    WatchEntry {
+                                        file_id: agent.file_id.clone(),
+                                        agent_block_id: agent.agent_block_id.clone(),
+                                        config_dir: agent.config_dir.clone(),
+                                    },
+                                );
+
+                                // Scan for existing .jsonl files
+                                if let Ok(entries) = std::fs::read_dir(path) {
+                                    for entry in entries.flatten() {
+                                        let file_path = entry.path();
+                                        if file_path.is_file() {
+                                            if let Some(ext) = file_path.extension() {
+                                                if ext == "jsonl" {
+                                                    let _ = event_tx_bridge.send(FileChangeEvent {
+                                                        path: file_path,
+                                                        agent_block_id: agent
+                                                            .agent_block_id
+                                                            .clone(),
+                                                        file_id: agent.file_id.clone(),
+                                                        config_dir: agent.config_dir.clone(),
+                                                    });
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+
+                        // Handle .jsonl file changes
+                        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                            continue;
+                        }
+
+                        // Skip temp/hidden files
+                        let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                        if filename.starts_with('.')
+                            || filename.ends_with(".tmp")
+                            || filename.ends_with(".swp")
+                        {
+                            continue;
+                        }
+
+                        // Find the matching watched directory
+                        if let Ok(dirs) = watched_dirs_bridge.lock() {
+                            for (dir, entry) in dirs.iter() {
+                                if path.starts_with(dir) {
+                                    let _ = event_tx_bridge.send(FileChangeEvent {
+                                        path: path.clone(),
+                                        agent_block_id: entry.agent_block_id.clone(),
+                                        file_id: entry.file_id.clone(),
+                                        config_dir: entry.config_dir.clone(),
+                                    });
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .map_err(|e| format!("Failed to spawn bridge thread: {}", e))?;
+
+        Ok((
+            Self {
+                watcher,
+                event_tx,
+                watched_dirs,
+                pending_agents,
+                watching_parent,
+                status_map: HashMap::new(),
+            },
+            event_rx,
+        ))
+    }
+
+    /// Start watching session directory for an Agent.
+    ///
+    /// If the session directory exists:
+    /// 1. Registers the directory with `notify`
+    /// 2. Scans existing `.jsonl` files and sends initial events
+    /// 3. Status becomes `Watching`
+    ///
+    /// If the session directory doesn't exist yet:
+    /// 1. Watches the parent directory (`~/.claude/projects/`)
+    /// 2. Adds agent to pending list
+    /// 3. Status becomes `WaitingForDirectory`
+    /// 4. When the directory is created, automatically starts watching
+    pub fn watch_agent(
+        &mut self,
+        file_id: &str,
+        agent_block_id: &str,
+        config_dir: &str,
+    ) -> Result<(), String> {
+        // Compute session directory (with case-insensitive fallback)
+        let session_dir = session_path::find_session_dir_from_config(config_dir)
+            .or_else(|| session_path::compute_session_dir_from_config(config_dir).ok());
+
+        let session_dir = match session_dir {
+            Some(dir) if dir.is_dir() => dir,
+            Some(dir) => {
+                // Directory doesn't exist yet — watch parent and wait
+                log::info!(
+                    "Session directory does not exist yet: {} (agent {}). Watching parent directory.",
+                    dir.display(),
+                    agent_block_id
+                );
+
+                // Add to pending agents
+                {
+                    let mut pending = self.pending_agents.lock().unwrap();
+                    pending.push(PendingAgent {
+                        file_id: file_id.to_string(),
+                        agent_block_id: agent_block_id.to_string(),
+                        config_dir: config_dir.to_string(),
+                        expected_session_dir: dir.clone(),
+                    });
+                }
+
+                // Watch parent directory (~/.claude/projects/) if not already watching
+                self.ensure_watching_parent()?;
+
+                self.status_map
+                    .insert(agent_block_id.to_string(), SyncStatus::WaitingForDirectory);
+                return Ok(());
+            }
+            None => {
+                log::warn!(
+                    "Cannot compute session directory for config_dir: {}",
+                    config_dir
+                );
+                self.status_map.insert(
+                    agent_block_id.to_string(),
+                    SyncStatus::Error("Cannot compute session directory".to_string()),
+                );
+                return Ok(());
+            }
+        };
+
+        // Register with notify (non-recursive — we only care about top-level .jsonl files)
+        self.watcher
+            .watcher()
+            .watch(&session_dir, RecursiveMode::NonRecursive)
+            .map_err(|e| format!("Failed to watch {}: {}", session_dir.display(), e))?;
+
+        // Insert into shared watched_dirs
+        {
+            let mut dirs = self.watched_dirs.lock().unwrap();
+            dirs.insert(
+                session_dir.clone(),
+                WatchEntry {
+                    file_id: file_id.to_string(),
+                    agent_block_id: agent_block_id.to_string(),
+                    config_dir: config_dir.to_string(),
+                },
+            );
+        }
+
+        self.status_map
+            .insert(agent_block_id.to_string(), SyncStatus::Watching);
+
+        // Initial scan: send events for all existing .jsonl files
+        if let Ok(entries) = std::fs::read_dir(&session_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_file() {
+                    if let Some(ext) = path.extension() {
+                        if ext == "jsonl" {
+                            let _ = self.event_tx.send(FileChangeEvent {
+                                path: path.clone(),
+                                agent_block_id: agent_block_id.to_string(),
+                                file_id: file_id.to_string(),
+                                config_dir: config_dir.to_string(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        log::info!(
+            "Session watcher started for agent {} at {}",
+            agent_block_id,
+            session_dir.display()
+        );
+
+        Ok(())
+    }
+
+    /// Ensure we're watching the parent directory (~/.claude/projects/).
+    ///
+    /// This is used to detect when new session directories are created.
+    fn ensure_watching_parent(&mut self) -> Result<(), String> {
+        let mut watching = self.watching_parent.lock().unwrap();
+        if *watching {
+            return Ok(());
+        }
+
+        let home = dirs::home_dir().ok_or("Cannot determine home directory")?;
+        let projects_dir = home.join(".claude").join("projects");
+
+        // Create the projects directory if it doesn't exist
+        if !projects_dir.exists() {
+            std::fs::create_dir_all(&projects_dir).map_err(|e| {
+                format!(
+                    "Failed to create projects directory {}: {}",
+                    projects_dir.display(),
+                    e
+                )
+            })?;
+        }
+
+        // Watch the projects directory (recursive to catch new subdirectories)
+        self.watcher
+            .watcher()
+            .watch(&projects_dir, RecursiveMode::Recursive)
+            .map_err(|e| format!("Failed to watch {}: {}", projects_dir.display(), e))?;
+
+        log::info!(
+            "Watching parent directory for new session directories: {}",
+            projects_dir.display()
+        );
+
+        *watching = true;
+        Ok(())
+    }
+
+    /// Stop watching session directory for an Agent.
+    ///
+    /// Also removes the agent from pending list if it was waiting for directory creation.
+    pub fn unwatch_agent(&mut self, agent_block_id: &str) -> Result<(), String> {
+        // Remove from watched directories
+        let dir_to_remove: Option<PathBuf> = {
+            let dirs = self.watched_dirs.lock().unwrap();
+            dirs.iter()
+                .find(|(_, entry)| entry.agent_block_id == agent_block_id)
+                .map(|(dir, _)| dir.clone())
+        };
+
+        if let Some(dir) = dir_to_remove {
+            let _ = self.watcher.watcher().unwatch(&dir);
+            let mut dirs = self.watched_dirs.lock().unwrap();
+            dirs.remove(&dir);
+        }
+
+        // Remove from pending agents (if waiting for directory creation)
+        {
+            let mut pending = self.pending_agents.lock().unwrap();
+            pending.retain(|agent| agent.agent_block_id != agent_block_id);
+        }
+
+        self.status_map
+            .insert(agent_block_id.to_string(), SyncStatus::Stopped);
+
+        log::info!("Session watcher stopped for agent {}", agent_block_id);
+        Ok(())
+    }
+
+    /// Get sync status for an Agent.
+    ///
+    /// Status is derived dynamically:
+    /// - If in watched_dirs: Watching
+    /// - If in pending_agents: WaitingForDirectory
+    /// - Otherwise: use status_map (Stopped or Error)
+    pub fn get_status(&self, agent_block_id: &str) -> SyncStatus {
+        // Check if actively watching
+        {
+            let dirs = self.watched_dirs.lock().unwrap();
+            for entry in dirs.values() {
+                if entry.agent_block_id == agent_block_id {
+                    return SyncStatus::Watching;
+                }
+            }
+        }
+
+        // Check if waiting for directory
+        {
+            let pending = self.pending_agents.lock().unwrap();
+            for agent in pending.iter() {
+                if agent.agent_block_id == agent_block_id {
+                    return SyncStatus::WaitingForDirectory;
+                }
+            }
+        }
+
+        // Fall back to stored status (Stopped or Error)
+        self.status_map
+            .get(agent_block_id)
+            .cloned()
+            .unwrap_or(SyncStatus::Stopped)
+    }
+
+    /// Get sync status for all Agents.
+    ///
+    /// Combines status from watched_dirs, pending_agents, and status_map.
+    pub fn get_all_status(&self) -> HashMap<String, SyncStatus> {
+        let mut result = self.status_map.clone();
+
+        // Add/update watching agents
+        {
+            let dirs = self.watched_dirs.lock().unwrap();
+            for entry in dirs.values() {
+                result.insert(entry.agent_block_id.clone(), SyncStatus::Watching);
+            }
+        }
+
+        // Add/update pending agents
+        {
+            let pending = self.pending_agents.lock().unwrap();
+            for agent in pending.iter() {
+                result.insert(
+                    agent.agent_block_id.clone(),
+                    SyncStatus::WaitingForDirectory,
+                );
+            }
+        }
+
+        result
+    }
+}

--- a/src-tauri/src/sync/writer.rs
+++ b/src-tauri/src/sync/writer.rs
@@ -1,0 +1,403 @@
+//! Session Block writer
+//!
+//! Writes parsed session documents into Elfiee Markdown Blocks as JSON content
+//! using the engine's command pipeline (event sourcing).
+//!
+//! Each JSONL session file maps to one Markdown Block. On first sync, the block
+//! is created via `core.create` then written with `markdown.write`. On subsequent
+//! syncs, new messages are appended to the JSON structure and metadata updated.
+
+use crate::engine::EngineHandle;
+use crate::models::Command;
+use crate::sync::parser::{create_session_data, SessionData, SessionDocument, SessionMetadata};
+use crate::utils::time::now_utc;
+use std::collections::HashMap;
+
+/// Session Block writer — maps session_id → block_id and writes JSON content.
+pub struct SessionWriter {
+    /// session_id → block_id cache
+    session_blocks: HashMap<String, String>,
+}
+
+impl SessionWriter {
+    pub fn new() -> Self {
+        Self {
+            session_blocks: HashMap::new(),
+        }
+    }
+
+    /// Write a SessionDocument to a Markdown Block as JSON content.
+    ///
+    /// Creates a new block if this is the first sync for the session, otherwise
+    /// appends new messages to the existing JSON structure.
+    pub async fn write_session(
+        &mut self,
+        handle: &EngineHandle,
+        editor_id: &str,
+        elf_block_id: &str,
+        project_name: &str,
+        config_dir: &str,
+        doc: SessionDocument,
+        source_file: &str,
+        source_offset: u64,
+    ) -> Result<(), String> {
+        let block_id = if let Some(id) = self.session_blocks.get(&doc.session_id) {
+            id.clone()
+        } else {
+            // Before creating a new block, check if one already exists in .elf/ directory
+            // This prevents duplicates if restore_offsets missed this session
+            if let Some(existing_id) = self
+                .find_existing_session_block(handle, elf_block_id, &doc.session_id)
+                .await
+            {
+                log::info!(
+                    "Found existing session block {} for session {} (was not in cache)",
+                    existing_id,
+                    doc.session_id
+                );
+                self.session_blocks
+                    .insert(doc.session_id.clone(), existing_id.clone());
+                existing_id
+            } else {
+                // Create new session block
+                let id = self
+                    .create_session_block(
+                        handle,
+                        editor_id,
+                        elf_block_id,
+                        &doc.session_id,
+                        project_name,
+                        config_dir,
+                        source_file,
+                        &doc.metadata,
+                    )
+                    .await?;
+                self.session_blocks
+                    .insert(doc.session_id.clone(), id.clone());
+                id
+            }
+        };
+
+        // Read existing block state (JSON content + message count)
+        let (existing_content, existing_msg_count) = self.read_block_state(handle, &block_id).await;
+
+        log::debug!(
+            "Session write: session_id={}, block_id={}, existing_len={}, new_messages={}, msg_count={}",
+            doc.session_id,
+            block_id,
+            existing_content.len(),
+            doc.new_messages.len(),
+            existing_msg_count
+        );
+
+        // Build or update SessionData structure
+        let mut session_data = if existing_content.is_empty() {
+            // First write — create new SessionData with metadata
+            create_session_data(&doc.metadata, &doc.session_id, project_name)
+        } else {
+            // Parse existing JSON content
+            SessionData::from_json(&existing_content).unwrap_or_else(|| {
+                log::warn!(
+                    "Failed to parse existing JSON for session {}, creating fresh",
+                    doc.session_id
+                );
+                create_session_data(&doc.metadata, &doc.session_id, project_name)
+            })
+        };
+
+        // Append new messages
+        session_data.messages.extend(doc.new_messages);
+
+        // Serialize to JSON
+        let new_content = session_data.to_json();
+
+        // Write content via markdown.write
+        let write_cmd = Command::new(
+            editor_id.to_string(),
+            "markdown.write".to_string(),
+            block_id.clone(),
+            serde_json::json!({ "content": new_content }),
+        );
+        handle.process_command(write_cmd).await?;
+
+        // Update metadata with sync progress (message_count is cumulative)
+        let meta_cmd = Command::new(
+            editor_id.to_string(),
+            "core.update_metadata".to_string(),
+            block_id,
+            serde_json::json!({
+                "metadata": {
+                    "sync_offset": source_offset,
+                    "message_count": existing_msg_count + doc.new_message_count as u64,
+                    "last_synced_at": now_utc()
+                }
+            }),
+        );
+        handle.process_command(meta_cmd).await?;
+
+        Ok(())
+    }
+
+    /// Create a new Markdown Block for a session.
+    async fn create_session_block(
+        &self,
+        handle: &EngineHandle,
+        editor_id: &str,
+        elf_block_id: &str,
+        session_id: &str,
+        project_name: &str,
+        config_dir: &str,
+        source_file: &str,
+        metadata: &SessionMetadata,
+    ) -> Result<String, String> {
+        let description = format!(
+            "Claude Code session for {} ({})",
+            project_name,
+            metadata.git_branch.as_deref().unwrap_or("unknown")
+        );
+
+        let create_cmd = Command::new(
+            editor_id.to_string(),
+            "core.create".to_string(),
+            "".to_string(),
+            serde_json::json!({
+                "name": format!("session_{}", session_id),
+                "block_type": "markdown",
+                "source": "outline",
+                "metadata": {
+                    "description": description,
+                    "session_id": session_id,
+                    "project_name": project_name,
+                    "config_dir": config_dir,
+                    "source_file": source_file,
+                    "sync_offset": 0,
+                    "model": metadata.model,
+                    "git_branch": metadata.git_branch,
+                    "message_count": 0,
+                    "last_synced_at": now_utc()
+                }
+            }),
+        );
+
+        let events = handle.process_command(create_cmd).await?;
+        let block_id = events
+            .first()
+            .ok_or("No event returned from core.create")?
+            .entity
+            .clone();
+
+        // Add entry to .elf/ session directory
+        self.add_session_entry(
+            handle,
+            editor_id,
+            elf_block_id,
+            project_name,
+            session_id,
+            &block_id,
+        )
+        .await?;
+
+        Ok(block_id)
+    }
+
+    /// Add a session entry to the .elf/ directory's entries map.
+    async fn add_session_entry(
+        &self,
+        handle: &EngineHandle,
+        editor_id: &str,
+        elf_block_id: &str,
+        project_name: &str,
+        session_id: &str,
+        block_id: &str,
+    ) -> Result<(), String> {
+        // Get current .elf/ directory entries
+        let elf_block = handle
+            .get_block(elf_block_id.to_string())
+            .await
+            .ok_or("Cannot find .elf/ directory block")?;
+
+        let mut entries = elf_block
+            .contents
+            .get("entries")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let entries_obj = entries.as_object_mut().ok_or("entries is not an object")?;
+
+        // Ensure session/{project}/ directory entry exists
+        let session_dir_key = format!("session/{}/", project_name);
+        if !entries_obj.contains_key(&session_dir_key) {
+            entries_obj.insert(
+                session_dir_key,
+                serde_json::json!({
+                    "id": format!("dir-session-{}", project_name),
+                    "type": "directory"
+                }),
+            );
+        }
+
+        // Add session file entry
+        let file_key = format!("session/{}/session_{}.json", project_name, session_id);
+        entries_obj.insert(
+            file_key,
+            serde_json::json!({
+                "id": block_id,
+                "type": "file",
+                "source": "outline",
+                "updated_at": now_utc()
+            }),
+        );
+
+        // Write updated entries
+        let write_cmd = Command::new(
+            editor_id.to_string(),
+            "directory.write".to_string(),
+            elf_block_id.to_string(),
+            serde_json::json!({
+                "entries": entries
+            }),
+        );
+        handle.process_command(write_cmd).await?;
+
+        Ok(())
+    }
+
+    /// Find an existing session block by session_id in the .elf/ directory entries.
+    ///
+    /// This is a defensive check to prevent creating duplicate blocks if the
+    /// session_blocks cache was not populated correctly by restore_offsets.
+    async fn find_existing_session_block(
+        &self,
+        handle: &EngineHandle,
+        elf_block_id: &str,
+        session_id: &str,
+    ) -> Option<String> {
+        let elf_block = handle.get_block(elf_block_id.to_string()).await?;
+        let entries = elf_block.contents.get("entries")?.as_object()?;
+
+        for (path, entry) in entries {
+            // Match pattern: session/*/session_{session_id}.json (or .md)
+            if !path.starts_with("session/") {
+                continue;
+            }
+            let is_json = path.ends_with(".json");
+            let is_md = path.ends_with(".md");
+            if !is_json && !is_md {
+                continue;
+            }
+
+            // Check if this entry matches our session_id
+            let expected_suffix_json = format!("/session_{}.json", session_id);
+            let expected_suffix_md = format!("/session_{}.md", session_id);
+            if path.ends_with(&expected_suffix_json) || path.ends_with(&expected_suffix_md) {
+                return entry.get("id").and_then(|v| v.as_str()).map(String::from);
+            }
+        }
+
+        None
+    }
+
+    /// Read current content and message count from a Markdown Block.
+    ///
+    /// Note: markdown.write stores content under `contents["markdown"]`, not `contents["content"]`.
+    async fn read_block_state(&self, handle: &EngineHandle, block_id: &str) -> (String, u64) {
+        if let Some(block) = handle.get_block(block_id.to_string()).await {
+            // markdown.write stores content under "markdown" key
+            let content = block
+                .contents
+                .get("markdown")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let msg_count = block
+                .metadata
+                .custom
+                .get("message_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            (content, msg_count)
+        } else {
+            (String::new(), 0)
+        }
+    }
+
+    /// Load existing session block mappings from the .elf/ directory.
+    ///
+    /// Scans .elf/ entries for `session/*/session_*.md` patterns and populates
+    /// the session_id → block_id cache. Also restores parser offsets from
+    /// block metadata.
+    pub async fn load_existing_sessions(
+        &mut self,
+        handle: &EngineHandle,
+        elf_block_id: &str,
+    ) -> Result<HashMap<String, u64>, String> {
+        let mut offset_map: HashMap<String, u64> = HashMap::new();
+
+        let elf_block = match handle.get_block(elf_block_id.to_string()).await {
+            Some(b) => b,
+            None => return Ok(offset_map),
+        };
+
+        let entries = match elf_block
+            .contents
+            .get("entries")
+            .and_then(|e| e.as_object())
+        {
+            Some(e) => e,
+            None => return Ok(offset_map),
+        };
+
+        for (path, entry) in entries {
+            // Match pattern: session/{project}/session_{uuid}.json (or .md for backwards compat)
+            if !path.starts_with("session/") {
+                continue;
+            }
+            let is_json = path.ends_with(".json");
+            let is_md = path.ends_with(".md");
+            if !is_json && !is_md {
+                continue;
+            }
+            let filename = path.rsplit('/').next().unwrap_or("");
+            if !filename.starts_with("session_") {
+                continue;
+            }
+
+            // Extract session_id: "session_abc-123.json" → "abc-123"
+            let session_id = filename
+                .strip_prefix("session_")
+                .and_then(|s| s.strip_suffix(".json").or_else(|| s.strip_suffix(".md")))
+                .unwrap_or("")
+                .to_string();
+
+            if session_id.is_empty() {
+                continue;
+            }
+
+            if let Some(block_id) = entry.get("id").and_then(|v| v.as_str()) {
+                self.session_blocks
+                    .insert(session_id.clone(), block_id.to_string());
+
+                // Try to restore sync_offset from block metadata.custom
+                if let Some(block) = handle.get_block(block_id.to_string()).await {
+                    if let Some(offset) = block
+                        .metadata
+                        .custom
+                        .get("sync_offset")
+                        .and_then(|v| v.as_u64())
+                    {
+                        if let Some(source_file) = block
+                            .metadata
+                            .custom
+                            .get("source_file")
+                            .and_then(|v| v.as_str())
+                        {
+                            offset_map.insert(source_file.to_string(), offset);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(offset_map)
+    }
+}


### PR DESCRIPTION
## Summary

- Implement session sync module that watches Claude Code JSONL session files and syncs them to Elfiee `.elf/` storage
- Use `notify-debouncer-mini` crate for proper 100ms file system event debouncing at source
- Support watching parent directory (`~/.claude/projects/`) when session directory doesn't exist yet
- Add incremental JSONL parsing with byte offset tracking to avoid re-processing

## Key Changes

### New Files
- `src-tauri/src/sync/mod.rs` - Top-level coordinator (SessionSyncManager)
- `src-tauri/src/sync/watcher.rs` - File system watcher with debouncing
- `src-tauri/src/sync/parser.rs` - Incremental JSONL parser
- `src-tauri/src/sync/writer.rs` - Markdown block writer
- `src-tauri/src/sync/session_path.rs` - Path encoding utilities
- `src-tauri/src/sync/tests.rs` - 30 comprehensive tests

### Modified Files
- `src-tauri/Cargo.toml` - Add notify-debouncer-mini dependency
- `src-tauri/src/commands/agent.rs` - Integrate session sync on agent create
- `src-tauri/src/state.rs` - Add SessionSyncManager to AppState

### Features
- **SyncStatus enum**: `Watching`, `WaitingForDirectory`, `Stopped`, `Error`
- **Case-insensitive path matching** for Windows compatibility
- **Automatic directory detection**: Watches parent and auto-activates when session dir is created

## Test plan

- [x] Run `cargo test sync` - All 30 tests passing
- [x] Manual test: Create agent when session directory doesn't exist
- [x] Manual test: Create agent with existing session directory
- [x] Manual test: Verify incremental sync on new JSONL content

Generated with [Claude Code](https://claude.ai/code)